### PR TITLE
refactor: remove password and activo fields from Cliente model and types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1336,6 +1337,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2045,6 +2047,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2840,6 +2843,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3638,6 +3642,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -4998,6 +5003,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -6151,6 +6157,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6240,6 +6247,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/models/Cliente.ts
+++ b/src/models/Cliente.ts
@@ -21,9 +21,6 @@ Cliente.init(
       type: DataTypes.STRING(50),
       unique: true,
     },
-    password: {
-      type: DataTypes.STRING(100),
-    },
     correo: {
       type: DataTypes.STRING(50),
     },
@@ -37,10 +34,6 @@ Cliente.init(
     },
     sexo: {
       type: DataTypes.STRING(10),
-    },
-    activo: {
-      type: DataTypes.BOOLEAN,
-      defaultValue: true,
     }
   },
   {

--- a/src/types/Cliente.ts
+++ b/src/types/Cliente.ts
@@ -3,7 +3,6 @@ export interface ClienteAttributes {
   nombre: string;
   apellido: string | null;
   cedula: string | null;
-  password: string | null;
   correo: string | null;
   asegurado: boolean;
   verificado: boolean;
@@ -16,7 +15,6 @@ export interface ClienteCreationAttributes {
   nombre?: string;
   apellido?: string | null;
   cedula?: string | null;
-  password?: string | null;
   correo?: string | null;
   asegurado?: boolean;
   verificado?: boolean;


### PR DESCRIPTION
This pull request removes the `password` and `activo` fields from the `Cliente` model and its related type definitions. These changes simplify the data model and ensure that sensitive or unnecessary fields are no longer part of the client representation.

Model and schema simplification:

* Removed the `password` field from the `Cliente` model definition in `src/models/Cliente.ts`, as well as from the `ClienteAttributes` and `ClienteCreationAttributes` interfaces in `src/types/Cliente.ts`. [[1]](diffhunk://#diff-0a7a70df8dcbaaebdcfcd1cd6d825c0db9b22c1882d6548650b43ba903594174L24-L26) [[2]](diffhunk://#diff-eded336513d64fc59abc1428e53c87ebda7512b459d72ea1d0c98ee873a9d350L6) [[3]](diffhunk://#diff-eded336513d64fc59abc1428e53c87ebda7512b459d72ea1d0c98ee873a9d350L19)
* Removed the `activo` boolean field from the `Cliente` model definition in `src/models/Cliente.ts`.