### PR TITLE
18 feat crear panel de administracion

### DIFF
--- a/api/src/controllers/SessionControll.ts
+++ b/api/src/controllers/SessionControll.ts
@@ -13,7 +13,7 @@ export async function Login(request: Request, response: Response) {
             return response.status(401).json({ error: 'Credenciales invalidas' });
         }
     
-        return response.status(200).json({ message: 'Inicio de sesión exitoso', session: {user: data.user?.id, access_token: data.session.access_token, refresh_token: data.session.refresh_token } });
+        return response.status(200).json({ message: 'Inicio de sesión exitoso', session: {user: {id: data.user?.id, email: data.user?.email}, access_token: data.session.access_token, refresh_token: data.session.refresh_token } });
 
     } catch (error) {
         return response.status(500).json({ error: 'Error interno del servidor' });
@@ -31,7 +31,7 @@ export async function SingUp(request: Request, response: Response) {
             return response.status(400).json({ error: 'Error al crear la cuenta', details: error.message });
         }
        
-        return response.status(201).json({ message: 'Cuenta creada exitosamente', session: { user: data.user?.id, access_token: data.session?.access_token, refresh_token: data.session?.refresh_token } });
+        return response.status(201).json({ message: 'Cuenta creada exitosamente', session: { user: { id: data.user?.id, email: data.user?.email }, access_token: data.session?.access_token, refresh_token: data.session?.refresh_token } });
     } catch (error) {
         return response.status(500).json({ error: 'Error interno del servidor' });
     }

--- a/api/src/middleware/validateAcceso.ts
+++ b/api/src/middleware/validateAcceso.ts
@@ -3,11 +3,6 @@ import type { Request, Response, NextFunction } from 'express';
 
 // Reglas de validación para crear un Acceso
 export const validateAccesoCreation = [
-  body('id')
-    .trim()
-    .notEmpty()
-    .withMessage('El id es requerido'),
-
   body('usuario')
     .trim()
     .notEmpty()

--- a/api/src/middleware/validateAcceso.ts
+++ b/api/src/middleware/validateAcceso.ts
@@ -3,25 +3,18 @@ import type { Request, Response, NextFunction } from 'express';
 
 // Reglas de validación para crear un Acceso
 export const validateAccesoCreation = [
-  body('usuario')
+  body('id')
     .trim()
     .notEmpty()
-    .withMessage('El usuario es requerido')
-    .isLength({ min: 3, max: 50 })
-    .withMessage('El usuario debe tener entre 3 y 50 caracteres'),
-
+    .withMessage('El ID es requerido')
+    .isUUID()
+    .withMessage('El ID debe ser un UUID válido'),
+  
   body('correo')
     .trim()
     .optional({ checkFalsy: true })
     .isEmail()
     .withMessage('El correo debe ser un email válido'),
-
-  body('tipo')
-    .trim()
-    .notEmpty()
-    .withMessage('El tipo es requerido')
-    .isLength({ min: 2, max: 20 })
-    .withMessage('El tipo debe tener entre 2 y 20 caracteres'),
 ];
 
 // Middleware para manejar errores de validación

--- a/api/src/models/Acceso.ts
+++ b/api/src/models/Acceso.ts
@@ -2,7 +2,7 @@ import { DataTypes, Model } from 'sequelize';
 import sequelize from '../config/sequelize.js';
 
 class Acceso extends Model {
-    declare id: number;
+    declare id: string;
     declare usuario: string;
     declare token: string;
     declare refresh: string;
@@ -13,15 +13,14 @@ Acceso.init(
     id: {
       type: DataTypes.STRING(255),
       primaryKey: true,
-    },
-    usuario: DataTypes.STRING(50),
-    correo: DataTypes.STRING(50),
-    tipo: DataTypes.STRING(20),
-    id_acceso: {
-      type: DataTypes.STRING(255),
-      allowNull: false,
       unique: true,
     },
+    usuario: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+    },
+    correo: DataTypes.STRING(50),
+    tipo: DataTypes.STRING(20),
     ultimo_acceso: DataTypes.DATE,
     activo: {
       type: DataTypes.BOOLEAN,

--- a/api/src/models/index.ts
+++ b/api/src/models/index.ts
@@ -9,8 +9,6 @@ import Maquina from "./Maquina.js";
 import Acceso from "./Acceso.js";
 
 /* Relaciones */
-Acceso.hasOne(Usuario, { foreignKey: "id_acceso",});
-Usuario.belongsTo(Acceso);
 
 Acceso.hasOne(Cliente, { foreignKey: "id_acceso" });
 Cliente.belongsTo(Acceso);

--- a/web/app/lib/api/QueryAcceso.ts
+++ b/web/app/lib/api/QueryAcceso.ts
@@ -7,6 +7,7 @@ export type CreateAccesoResponse = { message: string; acceso: { id: string } };
 export const useCreateAccesoMutation = () => {
   return useMutation({
     mutationFn: async (form: AccesoCreation): Promise<CreateAccesoResponse> => {
+      console.log("Creating acceso with form data:", form);
       return apiJson<CreateAccesoResponse>("/accesos", {
         method: "POST",
         body: form,
@@ -31,10 +32,10 @@ export const useUpdateAccesoActivoMutation = () => {
 export const useUpdateAccesoMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ id , activo }: { id: string; activo: boolean }) => {
+    mutationFn: async ({ id, body }: { id: string; body: AccesoUpdate }) => {
       return apiJson<{ message: string }>(`/accesos/${id}`, {
         method: "PUT",
-        body: { activo },
+        body,
         auth: true,
       });
     },

--- a/web/app/lib/api/QueryAcceso.ts
+++ b/web/app/lib/api/QueryAcceso.ts
@@ -22,7 +22,7 @@ export const useUpdateAccesoActivoMutation = () => {
     mutationFn: async ({ id, body} : {id: string, body: AccesoUpdate}) => {
       return apiJson<{ message: string }>(`/accesos/${id}`, {
         method: "PUT",
-        body: JSON.stringify({body}),
+        body: {...body},
         auth: true,
       });
     },

--- a/web/app/lib/api/QueryCliente.ts
+++ b/web/app/lib/api/QueryCliente.ts
@@ -1,7 +1,22 @@
-import { id } from 'zod/v4/locales';
-import { useMutation, useQuery } from "@tanstack/react-query";
-import type { Cliente } from "~/types/cliente";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { Cliente, ClienteUpdate } from "~/types/cliente";
 import { apiJson } from "../apiClient";
+
+export const useUpdateClienteMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: number; body: ClienteUpdate }) => {
+      return apiJson<{ message: string }>(`/clientes/${id}`, {
+        method: "PUT",
+        body,
+        auth: true,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["clientes"] });
+    },
+  });
+};
 
 export const useGetClientes = (id: string, enabled: boolean = true) => {
   const query = useQuery({

--- a/web/app/lib/api/QueryUsuario.ts
+++ b/web/app/lib/api/QueryUsuario.ts
@@ -1,6 +1,22 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
-import type { Usuario } from "~/types/Usuario";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { Usuario, UsuarioUpdate } from "~/types/Usuario";
 import { apiJson } from "../apiClient";
+
+export const useUpdateUsuarioMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: number; body: UsuarioUpdate }) => {
+      return apiJson<{ message: string }>(`/usuarios/${id}`, {
+        method: "PUT",
+        body,
+        auth: true,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["usuarios"] });
+    },
+  });
+};
 
 export const useGetUsuarios = (id: string, enabled: boolean = true) => {
   const query = useQuery({

--- a/web/app/pages/admin/components/AccesoTable.tsx
+++ b/web/app/pages/admin/components/AccesoTable.tsx
@@ -1,27 +1,85 @@
-import { Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography, CircularProgress, Alert, Button, Stack } from '@mui/material';
-import { useEffect, useState } from 'react';
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  CircularProgress,
+  Alert,
+  Button,
+  TextField,
+} from '@mui/material';
+import { useState } from 'react';
 import { useGetAccesos, useUpdateAccesoMutation } from '~/lib/api/QueryAcceso';
+import type { AccesoUpdate } from '~/types/Acceso';
 
 export function AccesoTable() {
-  const { data: accesos, isLoading, isError, error, refetch } = useGetAccesos("all");
+  const { data: accesos, isLoading, isError, error } = useGetAccesos('all');
   const updateMutation = useUpdateAccesoMutation();
   const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<AccesoUpdate>({});
+
+  const handleRowClick = (acceso: {
+    id: string;
+    usuario: string;
+    tipo: string;
+    correo: string;
+  }) => {
+    if (updatingId) return;
+    setEditingId(acceso.id);
+    setEditForm({
+      id: acceso.id,
+      usuario: acceso.usuario,
+      tipo: acceso.tipo,
+      correo: acceso.correo,
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditForm({});
+  };
+
+  const handleFieldChange = (field: keyof AccesoUpdate, value: string) => {
+    setEditForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSaveEdit = async (id: string) => {
+    setUpdatingId(id);
+    try {
+      await updateMutation.mutateAsync({ id, body: editForm });
+      handleCancelEdit();
+    } finally {
+      setUpdatingId(null);
+    }
+  };
 
   const handleToggleActivo = async (id: string, currentState: boolean) => {
     setUpdatingId(id);
     try {
-      await updateMutation.mutateAsync({ id, activo: !currentState });
+      await updateMutation.mutateAsync({ id, body: { activo: !currentState } });
     } finally {
       setUpdatingId(null);
     }
   };
 
   if (isLoading) {
-    return <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress /></Box>;
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
   }
 
   if (isError) {
-    return <Alert severity="error">Error al cargar accesos: {error?.message}</Alert>;
+    return (
+      <Alert severity="error">Error al cargar accesos: {error?.message}</Alert>
+    );
   }
 
   if (!accesos || accesos.length === 0) {
@@ -33,37 +91,149 @@ export function AccesoTable() {
       <Table>
         <TableHead sx={{ backgroundColor: '#f5f5f5' }}>
           <TableRow>
-            <TableCell><strong>ID</strong></TableCell>
-            <TableCell><strong>Usuario</strong></TableCell>
-            <TableCell><strong>Tipo</strong></TableCell>
-            <TableCell><strong>Correo</strong></TableCell>
-            <TableCell><strong>Activo</strong></TableCell>
-            <TableCell><strong>Último Acceso</strong></TableCell>
-            <TableCell><strong>Acciones</strong></TableCell>
+            <TableCell>
+              <strong>ID</strong>
+            </TableCell>
+            <TableCell>
+              <strong>Usuario</strong>
+            </TableCell>
+            <TableCell>
+              <strong>Tipo</strong>
+            </TableCell>
+            <TableCell>
+              <strong>Correo</strong>
+            </TableCell>
+            <TableCell>
+              <strong>Activo</strong>
+            </TableCell>
+            <TableCell>
+              <strong>Último Acceso</strong>
+            </TableCell>
+            <TableCell>
+              <strong>Acciones</strong>
+            </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {accesos.map((acceso) => (
-            <TableRow key={acceso.id} hover>
-              <TableCell>{acceso.id}</TableCell>
-              <TableCell>{acceso.usuario}</TableCell>
-              <TableCell>{acceso.tipo}</TableCell>
-              <TableCell>{acceso.correo}</TableCell>
-              <TableCell>{acceso.activo ? 'Sí' : 'No'}</TableCell>
+            <TableRow
+              key={acceso.id}
+              hover
+              onClick={() => handleRowClick(acceso)}
+              sx={{ cursor: updatingId ? 'wait' : 'pointer' }}
+            >
               <TableCell>
-                {acceso.ultimo_acceso ? new Date(acceso.ultimo_acceso).toLocaleDateString() : 'N/A'}
+                {editingId === acceso.id ? (
+                  <TextField
+                    value={editForm.id ?? ''}
+                    size="small"
+                    variant="outlined"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) =>
+                      handleFieldChange('id', e.target.value)
+                    }
+                  />
+                ) : (
+                  acceso.id
+                )}
               </TableCell>
               <TableCell>
-                <Button
-                  variant="contained"
-                  size="small"
-                  color={acceso.activo ? "error" : "success"}
-                  onClick={() => handleToggleActivo(acceso.id, acceso.activo)}
-                  disabled={updatingId === acceso.id}
-                  sx={{ minWidth: '100px' }}
-                >
-                  {updatingId === acceso.id ? <CircularProgress size={20} /> : (acceso.activo ? 'Desactivar' : 'Activar')}
-                </Button>
+                {editingId === acceso.id ? (
+                  <TextField
+                    value={editForm.usuario ?? ''}
+                    size="small"
+                    variant="outlined"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) =>
+                      handleFieldChange('usuario', e.target.value)
+                    }
+                  />
+                ) : (
+                  acceso.usuario
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === acceso.id ? (
+                  <TextField
+                    value={editForm.tipo ?? ''}
+                    size="small"
+                    variant="outlined"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('tipo', e.target.value)}
+                  />
+                ) : (
+                  acceso.tipo
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === acceso.id ? (
+                  <TextField
+                    value={editForm.correo ?? ''}
+                    size="small"
+                    variant="outlined"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) =>
+                      handleFieldChange('correo', e.target.value)
+                    }
+                  />
+                ) : (
+                  acceso.correo
+                )}
+              </TableCell>
+              <TableCell>{acceso.activo ? 'Sí' : 'No'}</TableCell>
+              <TableCell>
+                {acceso.ultimo_acceso
+                  ? new Date(acceso.ultimo_acceso).toLocaleDateString()
+                  : 'N/A'}
+              </TableCell>
+              <TableCell>
+                {editingId === acceso.id ? (
+                  <Box
+                    sx={{ display: 'flex', gap: 1 }}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <Button
+                      variant="contained"
+                      size="small"
+                      onClick={() => handleSaveEdit(acceso.id)}
+                      disabled={updatingId === acceso.id}
+                    >
+                      {updatingId === acceso.id ? (
+                        <CircularProgress size={20} />
+                      ) : (
+                        'Guardar'
+                      )}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={handleCancelEdit}
+                      disabled={updatingId === acceso.id}
+                    >
+                      Cancelar
+                    </Button>
+                  </Box>
+                ) : (
+                  <Button
+                    variant="contained"
+                    size="small"
+                    color={acceso.activo ? 'error' : 'success'}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleToggleActivo(acceso.id, acceso.activo);
+                    }}
+                    disabled={updatingId === acceso.id}
+                    sx={{ minWidth: '100px' }}
+                  >
+                    {updatingId === acceso.id ? (
+                      <CircularProgress size={20} />
+                    ) : acceso.activo ? (
+                      'Desactivar'
+                    ) : (
+                      'Activar'
+                    )}
+                  </Button>
+                )}
               </TableCell>
             </TableRow>
           ))}

--- a/web/app/pages/admin/components/ClienteTable.tsx
+++ b/web/app/pages/admin/components/ClienteTable.tsx
@@ -1,9 +1,71 @@
-import { Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography, CircularProgress, Alert } from '@mui/material';
-import { useEffect } from 'react';
-import { useGetClientes } from '~/lib/api/QueryCliente';
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  CircularProgress,
+  Alert,
+  Button,
+  TextField,
+  MenuItem,
+} from '@mui/material';
+import { useState } from 'react';
+import { useGetClientes, useUpdateClienteMutation } from '~/lib/api/QueryCliente';
+import type { ClienteUpdate } from '~/types/cliente';
 
 export function ClienteTable() {
-  const { data: clientes, isLoading, isError, error } = useGetClientes("all");
+  const { data: clientes, isLoading, isError, error } = useGetClientes('all');
+  const updateMutation = useUpdateClienteMutation();
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editForm, setEditForm] = useState<ClienteUpdate>({});
+
+  const handleRowClick = (cliente: {
+    id: number;
+    nombre: string;
+    apellido: string | null;
+    cedula: string | null;
+    correo: string | null;
+    asegurado: boolean;
+    verificado: boolean;
+    sexo: string | null;
+  }) => {
+    if (updatingId) return;
+    setEditingId(cliente.id);
+    setEditForm({
+      nombre: cliente.nombre,
+      apellido: cliente.apellido,
+      cedula: cliente.cedula,
+      correo: cliente.correo,
+      asegurado: cliente.asegurado,
+      verificado: cliente.verificado,
+      sexo: cliente.sexo,
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditForm({});
+  };
+
+  const handleFieldChange = (field: keyof ClienteUpdate, value: string | boolean | null) => {
+    setEditForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSaveEdit = async (id: number) => {
+    setUpdatingId(id);
+    try {
+      await updateMutation.mutateAsync({ id, body: editForm });
+      handleCancelEdit();
+    } finally {
+      setUpdatingId(null);
+    }
+  };
 
   if (isLoading) {
     return <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress /></Box>;
@@ -31,20 +93,150 @@ export function ClienteTable() {
             <TableCell><strong>Verificado</strong></TableCell>
             <TableCell><strong>Sexo</strong></TableCell>
             <TableCell><strong>ID Acceso</strong></TableCell>
+            <TableCell><strong>Acciones</strong></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {clientes.map((cliente) => (
-            <TableRow key={cliente.id} hover>
+            <TableRow
+              key={cliente.id}
+              hover
+              onClick={() => handleRowClick(cliente)}
+              sx={{ cursor: updatingId ? 'wait' : 'pointer' }}
+            >
               <TableCell>{cliente.id}</TableCell>
-              <TableCell>{cliente.nombre}</TableCell>
-              <TableCell>{cliente.apellido || 'N/A'}</TableCell>
-              <TableCell>{cliente.cedula || 'N/A'}</TableCell>
-              <TableCell>{cliente.correo || 'N/A'}</TableCell>
-              <TableCell>{cliente.asegurado ? 'Sí' : 'No'}</TableCell>
-              <TableCell>{cliente.verificado ? 'Sí' : 'No'}</TableCell>
-              <TableCell>{cliente.sexo || 'N/A'}</TableCell>
+              <TableCell>
+                {editingId === cliente.id ? (
+                  <TextField
+                    value={editForm.nombre ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('nombre', e.target.value)}
+                  />
+                ) : (
+                  cliente.nombre
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === cliente.id ? (
+                  <TextField
+                    value={editForm.apellido ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('apellido', e.target.value || null)}
+                  />
+                ) : (
+                  cliente.apellido || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === cliente.id ? (
+                  <TextField
+                    value={editForm.cedula ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('cedula', e.target.value || null)}
+                  />
+                ) : (
+                  cliente.cedula || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === cliente.id ? (
+                  <TextField
+                    value={editForm.correo ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('correo', e.target.value || null)}
+                  />
+                ) : (
+                  cliente.correo || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === cliente.id ? (
+                  <TextField
+                    select
+                    value={String(editForm.asegurado ?? false)}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('asegurado', e.target.value === 'true')}
+                  >
+                    <MenuItem value="true">Sí</MenuItem>
+                    <MenuItem value="false">No</MenuItem>
+                  </TextField>
+                ) : (
+                  cliente.asegurado ? 'Sí' : 'No'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === cliente.id ? (
+                  <TextField
+                    select
+                    value={String(editForm.verificado ?? false)}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('verificado', e.target.value === 'true')}
+                  >
+                    <MenuItem value="true">Sí</MenuItem>
+                    <MenuItem value="false">No</MenuItem>
+                  </TextField>
+                ) : (
+                  cliente.verificado ? 'Sí' : 'No'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === cliente.id ? (
+                  <TextField
+                    select
+                    value={editForm.sexo ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('sexo', e.target.value || null)}
+                  >
+                    <MenuItem value="">N/A</MenuItem>
+                    <MenuItem value="M">M</MenuItem>
+                    <MenuItem value="F">F</MenuItem>
+                    <MenuItem value="Otro">Otro</MenuItem>
+                  </TextField>
+                ) : (
+                  cliente.sexo || 'N/A'
+                )}
+              </TableCell>
               <TableCell>{cliente.id_acceso}</TableCell>
+              <TableCell>
+                {editingId === cliente.id ? (
+                  <Box sx={{ display: 'flex', gap: 1 }} onClick={(e) => e.stopPropagation()}>
+                    <Button
+                      variant="contained"
+                      size="small"
+                      onClick={() => handleSaveEdit(cliente.id)}
+                      disabled={updatingId === cliente.id}
+                    >
+                      {updatingId === cliente.id ? <CircularProgress size={20} /> : 'Guardar'}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={handleCancelEdit}
+                      disabled={updatingId === cliente.id}
+                    >
+                      Cancelar
+                    </Button>
+                  </Box>
+                ) : (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRowClick(cliente);
+                    }}
+                  >
+                    Editar
+                  </Button>
+                )}
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/web/app/pages/admin/components/CreateSupabaseUserForm.tsx
+++ b/web/app/pages/admin/components/CreateSupabaseUserForm.tsx
@@ -4,6 +4,7 @@ import { Stack, TextField, Typography, Button } from '@mui/material';
 import type { LoginData } from '~/types/login';
 import { LoginSchema } from '~/types/login';
 import { useSignupMutation } from '~/lib/Query';
+import { useCreateAccesoMutation } from '~/lib/api/QueryAcceso';
 
 export function CreateSupabaseUserForm() {
   const {
@@ -20,13 +21,18 @@ export function CreateSupabaseUserForm() {
   });
 
   const { mutate: signup, error, isError } = useSignupMutation();
-
+  const { mutateAsync: CreateAccess } = useCreateAccesoMutation();
+  
   const onSubmit = (data: LoginData) => {
     console.log('Create Supabase User data:', data);
-    // TODO: Implementar lógica de crear usuario de Supabase con fetch
     signup(data, {
       onSuccess: (response) => {
         console.log('Usuario creado exitosamente:', response);
+        CreateAccess({
+          id: response.session?.user.id || "",
+          correo: response.session?.user.email || "",
+          activo: true,
+        });
       },
       onError: (error) => {
         console.error('Error al crear usuario:', error);

--- a/web/app/pages/admin/components/CreateSupabaseUserForm.tsx
+++ b/web/app/pages/admin/components/CreateSupabaseUserForm.tsx
@@ -32,6 +32,7 @@ export function CreateSupabaseUserForm() {
           id: response.session?.user.id || "",
           correo: response.session?.user.email || "",
           activo: true,
+          usuario: response.session?.user.email || "",
         });
       },
       onError: (error) => {

--- a/web/app/pages/admin/components/UsuarioTable.tsx
+++ b/web/app/pages/admin/components/UsuarioTable.tsx
@@ -1,9 +1,69 @@
-import { Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography, CircularProgress, Alert } from '@mui/material';
-import { useEffect } from 'react';
-import { useGetUsuarios } from '~/lib/api/QueryUsuario';
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  CircularProgress,
+  Alert,
+  Button,
+  TextField,
+  MenuItem,
+} from '@mui/material';
+import { useState } from 'react';
+import { useGetUsuarios, useUpdateUsuarioMutation } from '~/lib/api/QueryUsuario';
+import type { UsuarioUpdate } from '~/types/Usuario';
 
 export function UsuarioTable() {
-  const { data: usuarios, isLoading, isError, error } = useGetUsuarios("all");
+  const { data: usuarios, isLoading, isError, error } = useGetUsuarios('all');
+  const updateMutation = useUpdateUsuarioMutation();
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editForm, setEditForm] = useState<UsuarioUpdate>({});
+
+  const handleRowClick = (usuario: {
+    id: number;
+    nombre: string | null;
+    apellido: string | null;
+    rol: string | null;
+    id_acceso: string | null;
+    ruc_doctor: string | null;
+    especialidades: string | null;
+  }) => {
+    if (updatingId) return;
+    setEditingId(usuario.id);
+    setEditForm({
+      nombre: usuario.nombre,
+      apellido: usuario.apellido,
+      rol: usuario.rol,
+      id_acceso: usuario.id_acceso,
+      ruc_doctor: usuario.ruc_doctor,
+      especialidades: usuario.especialidades,
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditForm({});
+  };
+
+  const handleFieldChange = (field: keyof UsuarioUpdate, value: string | null) => {
+    setEditForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSaveEdit = async (id: number) => {
+    setUpdatingId(id);
+    try {
+      await updateMutation.mutateAsync({ id, body: editForm });
+      handleCancelEdit();
+    } finally {
+      setUpdatingId(null);
+    }
+  };
 
   if (isLoading) {
     return <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress /></Box>;
@@ -29,18 +89,130 @@ export function UsuarioTable() {
             <TableCell><strong>ID Acceso</strong></TableCell>
             <TableCell><strong>RUC Doctor</strong></TableCell>
             <TableCell><strong>Especialidades</strong></TableCell>
+            <TableCell><strong>Acciones</strong></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {usuarios.map((usuario) => (
-            <TableRow key={usuario.id} hover>
+            <TableRow
+              key={usuario.id}
+              hover
+              onClick={() => handleRowClick(usuario)}
+              sx={{ cursor: updatingId ? 'wait' : 'pointer' }}
+            >
               <TableCell>{usuario.id}</TableCell>
-              <TableCell>{usuario.nombre || 'N/A'}</TableCell>
-              <TableCell>{usuario.apellido || 'N/A'}</TableCell>
-              <TableCell>{usuario.rol || 'N/A'}</TableCell>
-              <TableCell>{usuario.id_acceso || 'N/A'}</TableCell>
-              <TableCell>{usuario.ruc_doctor || 'N/A'}</TableCell>
-              <TableCell>{usuario.especialidades || 'N/A'}</TableCell>
+              <TableCell>
+                {editingId === usuario.id ? (
+                  <TextField
+                    value={editForm.nombre ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('nombre', e.target.value || null)}
+                  />
+                ) : (
+                  usuario.nombre || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === usuario.id ? (
+                  <TextField
+                    value={editForm.apellido ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('apellido', e.target.value || null)}
+                  />
+                ) : (
+                  usuario.apellido || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === usuario.id ? (
+                  <TextField
+                    select
+                    value={editForm.rol ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('rol', e.target.value || null)}
+                  >
+                    <MenuItem value="">N/A</MenuItem>
+                    <MenuItem value="admin">admin</MenuItem>
+                    <MenuItem value="doctor">doctor</MenuItem>
+                    <MenuItem value="farmacista">farmacista</MenuItem>
+                    <MenuItem value="cajero">cajero</MenuItem>
+                  </TextField>
+                ) : (
+                  usuario.rol || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === usuario.id ? (
+                  <TextField
+                    value={editForm.id_acceso ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('id_acceso', e.target.value || null)}
+                  />
+                ) : (
+                  usuario.id_acceso || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === usuario.id ? (
+                  <TextField
+                    value={editForm.ruc_doctor ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('ruc_doctor', e.target.value || null)}
+                  />
+                ) : (
+                  usuario.ruc_doctor || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === usuario.id ? (
+                  <TextField
+                    value={editForm.especialidades ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('especialidades', e.target.value || null)}
+                  />
+                ) : (
+                  usuario.especialidades || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === usuario.id ? (
+                  <Box sx={{ display: 'flex', gap: 1 }} onClick={(e) => e.stopPropagation()}>
+                    <Button
+                      variant="contained"
+                      size="small"
+                      onClick={() => handleSaveEdit(usuario.id)}
+                      disabled={updatingId === usuario.id}
+                    >
+                      {updatingId === usuario.id ? <CircularProgress size={20} /> : 'Guardar'}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={handleCancelEdit}
+                      disabled={updatingId === usuario.id}
+                    >
+                      Cancelar
+                    </Button>
+                  </Box>
+                ) : (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRowClick(usuario);
+                    }}
+                  >
+                    Editar
+                  </Button>
+                )}
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/web/app/pages/admin/components/UsuarioTable.tsx
+++ b/web/app/pages/admin/components/UsuarioTable.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import { useState } from 'react';
 import { useGetUsuarios, useUpdateUsuarioMutation } from '~/lib/api/QueryUsuario';
+import RefreshQuery from '~/lib/RefreshQuery';
 import type { UsuarioUpdate } from '~/types/Usuario';
 
 export function UsuarioTable() {
@@ -37,12 +38,12 @@ export function UsuarioTable() {
     if (updatingId) return;
     setEditingId(usuario.id);
     setEditForm({
-      nombre: usuario.nombre,
-      apellido: usuario.apellido,
-      rol: usuario.rol,
-      id_acceso: usuario.id_acceso,
-      ruc_doctor: usuario.ruc_doctor,
-      especialidades: usuario.especialidades,
+      nombre: usuario.nombre || "",
+      apellido: usuario.apellido || "",
+      rol: usuario.rol || "",
+      id_acceso: usuario.id_acceso || "",
+      ruc_doctor: usuario.ruc_doctor || "",
+      especialidades: usuario.especialidades || "",
     });
   };
 
@@ -60,6 +61,7 @@ export function UsuarioTable() {
     try {
       await updateMutation.mutateAsync({ id, body: editForm });
       handleCancelEdit();
+      RefreshQuery(['usuarios']); 
     } finally {
       setUpdatingId(null);
     }

--- a/web/app/pages/admin/route.tsx
+++ b/web/app/pages/admin/route.tsx
@@ -12,6 +12,7 @@ import { useGetAccesos } from '~/lib/api/QueryAcceso';
 import GetSession from '~/lib/GetSession';
 import CustomTabPanel from '~/components/CustomeTabPanel';
 import { useNavigate } from 'react-router';
+import type { Acceso } from '~/types/Acceso';
 
 export default function AdminPanel() {
   const [tabValue, setTabValue] = useState(0);
@@ -21,23 +22,20 @@ export default function AdminPanel() {
     setTabValue(newValue);
   };
   const sessionID = GetSession();
-  const { data, isError, refetch } = useGetAccesos(sessionID || "");
+  const { data, isError, isSuccess } = useGetAccesos(sessionID || "", true);
+
   useEffect(() => {
-    if(!sessionID){
-      navigate("/home");
-      return;
-    }
-    if(data && data?.length > 0) {
-      refetch();
-      const hasAdminAccess = data.some(acceso => acceso.tipo === 'admin');
-      if (!hasAdminAccess) {
+    if (isSuccess && !Array.isArray(data)) {
+      const acceso = data as Acceso
+      if (acceso?.tipo !== "admin") {
         navigate("/home");
       }
     }
-    if(isError){
+
+    if (isError) {
       navigate("/home");
     }
-  }, []);
+  }, [data, isError, isSuccess, navigate]);
 
   return (
     <Container component="main" maxWidth="lg">

--- a/web/app/pages/login/hook/useLogin.ts
+++ b/web/app/pages/login/hook/useLogin.ts
@@ -24,10 +24,15 @@ export function useLogin() {
     sessionStorage.setItem('sessionID', sessionID);
   }
 
+  function SaveID(ID: number){
+    sessionStorage.setItem('ID', ID.toString());
+  }
+
 
   return {
     SaveOnCokie,
     GetFromCookie,
-    SaveSession
+    SaveSession,
+    SaveID
   }
 }

--- a/web/app/pages/login/route.tsx
+++ b/web/app/pages/login/route.tsx
@@ -17,7 +17,7 @@ import { useLogin } from './hook/useLogin';
 import { useLoginMutation} from '~/lib/Query';
 import { useNavigate } from 'react-router';
 import { useEffect, useState } from 'react';
-import { useUpdateAccesoActivoMutation } from '~/lib/api/QueryAcceso';
+import { useCreateAccesoMutation, useUpdateAccesoActivoMutation } from '~/lib/api/QueryAcceso';
 
 export default function Login() {
   const {
@@ -30,7 +30,7 @@ export default function Login() {
   const navigate = useNavigate();
   const { SaveOnCokie, SaveSession } = useLogin();  
   const { mutateAsync, isError, isSuccess, error } = useLoginMutation();
-  const {mutateAsync: UpdateAccess} = useUpdateAccesoActivoMutation();
+  const { mutateAsync: UpdateAccess } = useUpdateAccesoActivoMutation();
   const [sessionID, setSessionID] = useState<string | null>(null);
     useEffect(() => {
     if (isSuccess) {
@@ -44,7 +44,7 @@ export default function Login() {
       const result = await mutateAsync(formData);
       if (result?.session?.access_token && result?.session?.refresh_token) {
         SaveOnCokie(result.session.access_token, result.session.refresh_token);
-        setSessionID(result.session.user);
+        setSessionID(result.session.user.id);
       }
     } catch {
       // Errors are surfaced via react-query state (isError/error)

--- a/web/app/types/Acceso.ts
+++ b/web/app/types/Acceso.ts
@@ -3,7 +3,7 @@ import { id } from 'zod/v4/locales';
 
 // Schema para lectura (todas las propiedades)
 export const AccesoSchema = z.object({
-  id: z.string(),
+  id: z.uuid(),
   usuario: z.string(),
   tipo: z.string(),
   ultimo_acceso: z.coerce.date().nullable(),
@@ -14,9 +14,9 @@ export const AccesoSchema = z.object({
 
 // Schema para creación
 export const AccesoCreationSchema = z.object({
-  id: z.string().nonempty('El ID es requerido'),
-  usuario: z.string().min(1, 'El usuario es requerido'),
-  tipo: z.string().min(1, 'El tipo es requerido'),
+  id: z.uuid('ID inválido'),
+  usuario: z.string().min(1, 'El usuario es requerido').optional(),
+  tipo: z.string().min(1, 'El tipo es requerido').optional(),
   ultimo_acceso: z.coerce.date().nullable().optional(),
   correo: z.email('Email inválido'),
   activo: z.boolean().optional().default(true),

--- a/web/app/types/Usuario.ts
+++ b/web/app/types/Usuario.ts
@@ -21,6 +21,9 @@ export const UsuarioCreationSchema = z.object({
   especialidades: z.string().nullable().optional(),
 });
 
+export const UsuarioUpdateSchema = UsuarioCreationSchema.partial();
+
 // Types derivados
 export type Usuario = z.infer<typeof UsuarioSchema>;
 export type UsuarioCreation = z.infer<typeof UsuarioCreationSchema>;
+export type UsuarioUpdate = z.infer<typeof UsuarioUpdateSchema>;

--- a/web/app/types/login.ts
+++ b/web/app/types/login.ts
@@ -10,7 +10,10 @@ export type LoginData = z.infer<typeof LoginSchema>;
 export const LoginResponse = z.object({
   message: z.string(),
   session: z.object({
-    user: z.string(),
+    user: z.object({
+      id: z.string(),
+      email: z.email(),
+    }),
     access_token: z.string(),
     refresh_token: z.string(),
   }).optional(),


### PR DESCRIPTION
This pull request introduces significant improvements to both the backend and frontend related to the management and editing of `Acceso`, `Cliente`, and `Usuario` entities. The main changes include enhanced API responses, improved validation and data modeling, and the addition of inline editing capabilities in the admin tables for `Acceso` and `Cliente`.

**Backend Improvements:**

- **API Response Enhancements:**
  - The session-related API responses for login and signup now return user objects containing both `id` and `email`, providing more detailed user information in the session payload. [[1]](diffhunk://#diff-5616d0960e41a473578fe32e5235ba10eeda467081b367a7d15fb2f96f463518L16-R16) [[2]](diffhunk://#diff-5616d0960e41a473578fe32e5235ba10eeda467081b367a7d15fb2f96f463518L34-R34)

- **Validation and Data Model Updates:**
  - The `Acceso` model's `id` is now a UUID string (was previously a number), and validation enforces this format. The model no longer requires or includes the `id_acceso` field, and the `usuario` field is now nullable. [[1]](diffhunk://#diff-af2b37c79275e5b25a8998f701023a0bc5016e5b38a4845ef4961430f3eeb890L5-R5) [[2]](diffhunk://#diff-af2b37c79275e5b25a8998f701023a0bc5016e5b38a4845ef4961430f3eeb890R16-L24) [[3]](diffhunk://#diff-077bf6141bbcce024259d0754d0f1f4507b5b29463176e80a32f3db9592521e9L9-L29)
  - Relationship between `Acceso` and `Usuario` has been removed from the model index, reflecting changes in the data model.

**Frontend Improvements:**

- **Inline Editing in Admin Tables:**
  - The `AccesoTable` and `ClienteTable` components now support inline editing of records. Users can click on a row to edit fields directly within the table, with options to save or cancel changes. These changes are sent to the backend using new or updated mutation hooks. [[1]](diffhunk://#diff-db78cf3e02a91d97627aee16f2ce4922db092d69450fce7f8cff86ca022facd1L1-R82) [[2]](diffhunk://#diff-db78cf3e02a91d97627aee16f2ce4922db092d69450fce7f8cff86ca022facd1L36-R236) [[3]](diffhunk://#diff-f89fad8554f925e5d8d372aa39f44e93c78282badcf14f4c02d0762ee8b4e1f7L1-R68)

- **API Mutation Hooks:**
  - New mutation hooks for updating `Cliente` and `Usuario` entities have been added, enabling the frontend to send update requests and automatically refresh data after successful updates. Update hooks for `Acceso` have also been refactored for consistency and to support the new editing features. [[1]](diffhunk://#diff-3490e83991561bfb90a6a006fb57e481cee1c1a5408bf25ad2e97712beacf4a9L1-R20) [[2]](diffhunk://#diff-eb83b522f1e8b01cf1f9e7fa741ddab37df762008c6c7e8555f4b188cebd9371L1-R20) [[3]](diffhunk://#diff-f2e3078e64cd8b9c045d850c2d6cd2b3acb0f431b120f11559fb9a21e27815f9L24-R25) [[4]](diffhunk://#diff-f2e3078e64cd8b9c045d850c2d6cd2b3acb0f431b120f11559fb9a21e27815f9L34-R38)

- **Developer Experience:**
  - Added logging for `useCreateAccesoMutation` to aid debugging during development.

**Summary of Most Important Changes:**

**Backend:**

* Enhanced session API responses to include both user `id` and `email` in the session object for login and signup endpoints (`SessionControll.ts`). [[1]](diffhunk://#diff-5616d0960e41a473578fe32e5235ba10eeda467081b367a7d15fb2f96f463518L16-R16) [[2]](diffhunk://#diff-5616d0960e41a473578fe32e5235ba10eeda467081b367a7d15fb2f96f463518L34-R34)
* Updated `Acceso` model: changed `id` to a UUID string, made `usuario` nullable, removed `id_acceso`, and updated validation to enforce UUID format (`Acceso.ts`, `validateAcceso.ts`). [[1]](diffhunk://#diff-af2b37c79275e5b25a8998f701023a0bc5016e5b38a4845ef4961430f3eeb890L5-R5) [[2]](diffhunk://#diff-af2b37c79275e5b25a8998f701023a0bc5016e5b38a4845ef4961430f3eeb890R16-L24) [[3]](diffhunk://#diff-077bf6141bbcce024259d0754d0f1f4507b5b29463176e80a32f3db9592521e9L9-L29)
* Removed the relationship between `Acceso` and `Usuario` in the model index, reflecting the updated data model (`index.ts`).

**Frontend:**

* Added inline editing capability to the `AccesoTable` and `ClienteTable` components, allowing users to edit records directly in the table and save or cancel changes (`AccesoTable.tsx`, `ClienteTable.tsx`). [[1]](diffhunk://#diff-db78cf3e02a91d97627aee16f2ce4922db092d69450fce7f8cff86ca022facd1L1-R82) [[2]](diffhunk://#diff-db78cf3e02a91d97627aee16f2ce4922db092d69450fce7f8cff86ca022facd1L36-R236) [[3]](diffhunk://#diff-f89fad8554f925e5d8d372aa39f44e93c78282badcf14f4c02d0762ee8b4e1f7L1-R68)
* Introduced and refactored mutation hooks for updating `Acceso`, `Cliente`, and `Usuario` entities, improving data update flows and cache invalidation (`QueryAcceso.ts`, `QueryCliente.ts`, `QueryUsuario.ts`). [[1]](diffhunk://#diff-3490e83991561bfb90a6a006fb57e481cee1c1a5408bf25ad2e97712beacf4a9L1-R20) [[2]](diffhunk://#diff-eb83b522f1e8b01cf1f9e7fa741ddab37df762008c6c7e8555f4b188cebd9371L1-R20) [[3]](diffhunk://#diff-f2e3078e64cd8b9c045d850c2d6cd2b3acb0f431b120f11559fb9a21e27815f9L24-R25) [[4]](diffhunk://#diff-f2e3078e64cd8b9c045d850c2d6cd2b3acb0f431b120f11559fb9a21e27815f9L34-R38)
* Added logging for `useCreateAccesoMutation` to aid in debugging (`QueryAcceso.ts`).