### PR TITLE
23 feat leer recetas usando la cedula del cliente

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -11,6 +11,7 @@ import RouteInventario from "./routes/Route_Inventario.js";
 import RouteMaquina from "./routes/Route_Maquina.js";
 import requireSupabaseAuth from "./middleware/requireSupabaseAuth.js";
 import RouteSession from "./routes/Route_Session.js";
+import RouteGetRecetaByCedula from "./routes/Route-GetRecetaByCedula.js";
 import "./models/index.js";
 
 const app = express();
@@ -26,8 +27,8 @@ app.use(cors(
 
 app.use(express.json());
 app.use(prefix, RouteSession);
+app.use(prefix, RouteGetRecetaByCedula);
 app.use(prefix, requireSupabaseAuth);
-
 app.use(prefix, RouteAcceso);
 app.use(prefix, RouteCliente);
 app.use(prefix, RouteUsuario);

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -20,7 +20,7 @@ const prefix = "/api/v0";
 
 app.use(cors(
   {
-    origin: "http://localhost:5173",
+    origin: "http://localhost:5173", // TODO: Cambiar por sistema de Variables de entorno
     credentials: true,
   }
 ))

--- a/api/src/controllers/GetRecetaByCedula.ts
+++ b/api/src/controllers/GetRecetaByCedula.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express';
+import Receta from '../models/Receta.js';
+import Cliente from '../models/Cliente.js';
+
+export default async function GetRecetaByCedula(request: Request, response: Response) {
+    try {
+        const cedula = request.params.cedula;
+        if (!cedula) {
+            return response.status(400).json({ error: 'Cédula es requerida' });
+        }
+        const cliente = await Cliente.findOne({ where: { cedula } });
+        if (!cliente) {
+            return response.status(404).json({ error: 'Cliente no encontrado' });
+        }
+        const res = await Receta.findOne({ where: { id_cliente: cliente.id } });
+        if (!res) {
+            return response.status(404).json({ error: 'Receta no encontrada' });
+        }
+        response.json(res);
+    } catch (error) {
+        response.status(500).json({ error: 'Error al buscar la receta' });
+    }
+}

--- a/api/src/models/Cliente.ts
+++ b/api/src/models/Cliente.ts
@@ -1,7 +1,16 @@
 import { DataTypes, Model } from "sequelize";
 import sequelize from "../config/sequelize.js";
 
-class Cliente extends Model {}
+class Cliente extends Model {
+  declare id: number;
+  declare nombre: string;
+  declare cedula: string;
+  declare apellido: string;
+  declare correo: string;
+  declare asegurado: boolean;
+  declare verificado: boolean;
+  declare sexo: string;
+}
 
 Cliente.init(
   {

--- a/api/src/routes/Route-GetRecetaByCedula.ts
+++ b/api/src/routes/Route-GetRecetaByCedula.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import GetRecetaByCedula from '../controllers/GetRecetaByCedula.js';
+
+const router = Router();
+router.get('/recetas/cliente/:cedula', GetRecetaByCedula);
+
+export default router;

--- a/api/src/routes/Route_Receta.ts
+++ b/api/src/routes/Route_Receta.ts
@@ -1,4 +1,3 @@
-import GetRecetaByCedula from '../controllers/GetRecetaByCedula.js';
 import { CREATE, READ, UPDATE, DELETE } from '../controllers/CRUD_Receta.js';
 import { validateRecetaCreation, handleValidationErrors } from '../middleware/validateReceta.js';
 import { Router } from 'express';
@@ -9,6 +8,5 @@ router.post('/recetas', validateRecetaCreation, handleValidationErrors, CREATE);
 router.get('/recetas/:id', READ);
 router.put('/recetas/:id', validateRecetaCreation, handleValidationErrors, UPDATE);
 router.delete('/recetas/:id', DELETE);
-router.get('/recetas/cliente/:cedula', GetRecetaByCedula);
 
 export default router;

--- a/api/src/routes/Route_Receta.ts
+++ b/api/src/routes/Route_Receta.ts
@@ -1,3 +1,4 @@
+import GetRecetaByCedula from '../controllers/GetRecetaByCedula.js';
 import { CREATE, READ, UPDATE, DELETE } from '../controllers/CRUD_Receta.js';
 import { validateRecetaCreation, handleValidationErrors } from '../middleware/validateReceta.js';
 import { Router } from 'express';
@@ -8,5 +9,6 @@ router.post('/recetas', validateRecetaCreation, handleValidationErrors, CREATE);
 router.get('/recetas/:id', READ);
 router.put('/recetas/:id', validateRecetaCreation, handleValidationErrors, UPDATE);
 router.delete('/recetas/:id', DELETE);
+router.get('/recetas/cliente/:cedula', GetRecetaByCedula);
 
 export default router;


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve a client's prescription (`Receta`) by their national ID (`cedula`). It includes the controller logic, route registration, and necessary model typing improvements to support this feature.

**New Endpoint for Fetching Prescription by Cedula:**

* Added a new controller `GetRecetaByCedula` that looks up a `Cliente` by `cedula` and returns their associated `Receta`, with appropriate error handling for missing or not found resources.
* Created a new route file `Route-GetRecetaByCedula.ts` that registers the endpoint `GET /recetas/cliente/:cedula` and connects it to the new controller.
* Registered the new route in the main app, making it available under the `/api/v0` prefix. [[1]](diffhunk://#diff-25a01e9a04ab4c3ad41e3be9ab5c63c516065aa0a3da53c7f7ef17b65f6ae916R14) [[2]](diffhunk://#diff-25a01e9a04ab4c3ad41e3be9ab5c63c516065aa0a3da53c7f7ef17b65f6ae916L22-L30)

**Model Improvements:**

* Updated the `Cliente` model to explicitly declare its TypeScript properties, improving type safety and clarity in the codebase.