### PR TITLE
feat: add endpoint to create receta by client ID using cedula

### DIFF
--- a/api/src/controllers/PostRecetaByCedula.ts
+++ b/api/src/controllers/PostRecetaByCedula.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express';
+import Receta from '../models/Receta.js';
+import Cliente from '../models/Cliente.js';
+import { RecetaCreationAttributes } from '../types';
+
+
+export default async function PostRecetaByCedula(req: Request, res: Response) {
+    const cedula = req.params.cedula;
+    try{
+        const cliente = await Cliente.findOne({ where: { cedula } });
+        if (!cliente) {
+            return res.status(404).json({ message: 'Cliente no encontrado' });
+        }
+        const body: RecetaCreationAttributes = {...req.body, id_cliente: cliente.id }; // Inicializamos id_cliente con un valor temporal
+        await Receta.create({body});
+        res.status(201).json({ message: 'Receta creada exitosamente' });
+    } catch (error) {
+        console.error('Error al crear la receta:', error);
+        res.status(500).json({ message: 'Error interno del servidor' });
+    }
+}

--- a/api/src/routes/Route_Receta.ts
+++ b/api/src/routes/Route_Receta.ts
@@ -1,4 +1,5 @@
 import { CREATE, READ, UPDATE, DELETE } from '../controllers/CRUD_Receta.js';
+import PostRecetaByCedula from '../controllers/PostRecetaByCedula.js';
 import { validateRecetaCreation, handleValidationErrors } from '../middleware/validateReceta.js';
 import { Router } from 'express';
 
@@ -8,5 +9,6 @@ router.post('/recetas', validateRecetaCreation, handleValidationErrors, CREATE);
 router.get('/recetas/:id', READ);
 router.put('/recetas/:id', validateRecetaCreation, handleValidationErrors, UPDATE);
 router.delete('/recetas/:id', DELETE);
+router.post('/recetas/cedula/:cedula', validateRecetaCreation, handleValidationErrors, PostRecetaByCedula);
 
 export default router;


### PR DESCRIPTION
This pull request introduces a new endpoint for creating a `Receta` (prescription) by a client's `cedula` (ID number), enhancing the API's flexibility for client-specific operations. The main changes include the implementation of a new controller and the integration of a new route.

**New functionality for creating prescriptions by client ID:**

* Added a new controller function `PostRecetaByCedula` in `PostRecetaByCedula.ts` that finds a `Cliente` by `cedula`, attaches the client's ID to the prescription, and creates the `Receta`. Handles errors for missing clients and server issues.
* Registered the new controller in the routes file `Route_Receta.ts` to make it available for routing.
* Added a new POST route `/recetas/cedula/:cedula` in `Route_Receta.ts`, which validates the request and uses `PostRecetaByCedula` to create a `Receta` for the specified client.