### PR TITLE
feat: implement cookie store functions for token management and add r…

### DIFF
--- a/web/app/lib/GetCookie.ts
+++ b/web/app/lib/GetCookie.ts
@@ -1,0 +1,41 @@
+
+
+export async function readCookieStoreValue(key: string): Promise<string | null> {
+  if (typeof window === "undefined") return null;
+  const anyWindow = window as any;
+  if (!anyWindow.cookieStore?.get) return null;
+  try {
+    const cookie = await anyWindow.cookieStore.get(key);
+    return cookie?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getAccessToken(): Promise<string | null> {
+  const fromCookieStore = await readCookieStoreValue("token");
+  if (fromCookieStore) return fromCookieStore;
+
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("token");
+}
+
+export async function getRefreshToken(): Promise<string | null> {
+  const fromCookieStore = await readCookieStoreValue("refresh_token");
+  if (fromCookieStore) return fromCookieStore;
+
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("refresh_token");
+}
+
+export async function saveCookieStoreValue(key: string, value: string) {
+  if (typeof window === "undefined") return;
+  const anyWindow = window as any;
+  if (anyWindow.cookieStore?.set) {
+    try {
+      await anyWindow.cookieStore.set({ name: key, value, path: "/" });
+    } catch {
+      // Ignore errors
+    }
+  }
+}

--- a/web/app/lib/apiClient.ts
+++ b/web/app/lib/apiClient.ts
@@ -1,30 +1,11 @@
 import { API_URL } from "~/config/ApiConfig";
+import { getAccessToken, getRefreshToken, saveCookieStoreValue } from "./GetCookie";
 
 type ApiFetchOptions = Omit<RequestInit, "body" | "headers"> & {
   body?: unknown;
   headers?: HeadersInit;
   auth?: boolean;
 };
-
-async function readCookieStoreValue(key: string): Promise<string | null> {
-  if (typeof window === "undefined") return null;
-  const anyWindow = window as any;
-  if (!anyWindow.cookieStore?.get) return null;
-  try {
-    const cookie = await anyWindow.cookieStore.get(key);
-    return cookie?.value ?? null;
-  } catch {
-    return null;
-  }
-}
-
-export async function getAccessToken(): Promise<string | null> {
-  const fromCookieStore = await readCookieStoreValue("token");
-  if (fromCookieStore) return fromCookieStore;
-
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem("token");
-}
 
 function buildUrl(path: string) {
   if (!API_URL) return path;
@@ -80,6 +61,23 @@ export async function apiJson<T>(path: string, options: ApiFetchOptions = {}): P
     headers,
     body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
   });
+
+  if(response.status === 401) {
+    const refresh = await getRefreshToken();
+    if (!refresh) {
+      throw new Error("No hay token de sesión; inicia sesión nuevamente");
+    }
+    const refreshResponse = await fetch(buildUrl("/auth/refresh-token"), {
+      method: "POST",
+      body: JSON.stringify({ refresh_token: refresh }),
+      headers: { "Content-Type": "application/json" },
+    }).then(res => res.json());
+
+    if (refreshResponse?.session?.access_token) {
+      await saveCookieStoreValue("token", refreshResponse.session.access_token);
+      return apiJson(path, options);
+    }
+  }
 
   const contentType = response.headers.get("content-type") || "";
   const isJson = contentType.includes("application/json");


### PR DESCRIPTION
This pull request refactors authentication token handling in the frontend by centralizing cookie and localStorage access logic into a new utility module. It also improves the API client to automatically refresh the access token on 401 responses using the refresh token, enhancing user session reliability.

**Authentication token management improvements:**

* Extracted functions for reading, saving, and retrieving access and refresh tokens into a new utility file `GetCookie.ts`, consolidating token management and reducing code duplication.
* Updated `apiClient.ts` to use the new token utility functions, removing redundant implementations and ensuring consistent token handling throughout the codebase.

**Session refresh logic:**

* Enhanced the `apiJson` function in `apiClient.ts` to automatically attempt an access token refresh using the refresh token when a 401 Unauthorized response is received. If successful, the new token is saved and the original request is retried, improving the user experience during session expiration