### PR TITLE
18 feat crear panel de administracion

### DIFF
--- a/web/app/lib/api/QueryInventario.ts
+++ b/web/app/lib/api/QueryInventario.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { Inventario, InventarioCreation, InventarioUpdate } from '~/types/Inventario';
+import { apiJson } from '../apiClient';
+
+export const useCreateInventarioMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (form: InventarioCreation): Promise<Inventario> => {
+      return apiJson<Inventario>('/inventario', {
+        method: 'POST',
+        body: form,
+        auth: true,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['inventarios'] });
+    },
+  });
+};
+
+export const useUpdateInventarioMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: number; body: InventarioUpdate }) => {
+      return apiJson<Inventario>(`/inventario/${id}`, {
+        method: 'PUT',
+        body,
+        auth: true,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['inventarios'] });
+    },
+  });
+};
+
+export const useGetInventarios = (id: string, enabled: boolean = true) => {
+  return useQuery({
+    queryKey: ['inventarios', id],
+    queryFn: async (): Promise<Inventario[]> => {
+      return apiJson<Inventario[]>(`/inventario/${id}`, {
+        method: 'GET',
+        auth: true,
+      });
+    },
+    enabled,
+  });
+};

--- a/web/app/lib/api/QueryMaquina.ts
+++ b/web/app/lib/api/QueryMaquina.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { Maquina, MaquinaCreation, MaquinaUpdate } from '~/types/Maquina';
+import { apiJson } from '../apiClient';
+
+export const useCreateMaquinaMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (form: MaquinaCreation): Promise<Maquina> => {
+      return apiJson<Maquina>('/maquinas', {
+        method: 'POST',
+        body: form,
+        auth: true,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['maquinas'] });
+    },
+  });
+};
+
+export const useUpdateMaquinaMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: number; body: MaquinaUpdate }) => {
+      return apiJson<Maquina>(`/maquinas/${id}`, {
+        method: 'PUT',
+        body,
+        auth: true,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['maquinas'] });
+    },
+  });
+};
+
+export const useGetMaquinas = (id: string, enabled: boolean = true) => {
+  return useQuery({
+    queryKey: ['maquinas', id],
+    queryFn: async (): Promise<Maquina[]> => {
+      return apiJson<Maquina[]>(`/maquinas/${id}`, {
+        method: 'GET',
+        auth: true,
+      });
+    },
+    enabled,
+  });
+};

--- a/web/app/pages/admin/components/InventarioForm.tsx
+++ b/web/app/pages/admin/components/InventarioForm.tsx
@@ -1,0 +1,158 @@
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, Checkbox, FormControlLabel, Stack, TextField, Typography } from '@mui/material';
+import { useCreateInventarioMutation } from '~/lib/api/QueryInventario';
+import type { InventarioCreation } from '~/types/Inventario';
+import { InventarioCreationSchema } from '~/types/Inventario';
+
+export function InventarioForm() {
+  const {
+    handleSubmit,
+    formState: { errors },
+    control,
+    reset,
+  } = useForm<InventarioCreation>({
+    resolver: zodResolver(InventarioCreationSchema),
+    defaultValues: {
+      id_maquina: undefined,
+      nombre_medicamento: '',
+      marca: '',
+      precio: null,
+      cantidad: null,
+      resetado: false,
+    },
+  });
+
+  const { mutate, isPending, isError, error, isSuccess } = useCreateInventarioMutation();
+
+  const onSubmit = (data: InventarioCreation) => {
+    mutate(data, {
+      onSuccess: () => reset(),
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Stack spacing={2}>
+        {isSuccess && (
+          <Typography variant="body2" sx={{ color: 'success.main' }}>
+            Inventario creado exitosamente
+          </Typography>
+        )}
+
+        {isError && (
+          <Typography variant="body2" sx={{ color: 'error.main' }}>
+            {error instanceof Error ? error.message : 'Error al crear inventario'}
+          </Typography>
+        )}
+
+        <Controller
+          name="id_maquina"
+          control={control}
+          render={({ field }) => (
+            <>
+              {errors.id_maquina && (
+                <Typography variant="body2" sx={{ color: 'error.main' }}>
+                  {errors.id_maquina.message}
+                </Typography>
+              )}
+              <TextField
+                fullWidth
+                label="ID de la máquina"
+                type="number"
+                variant="outlined"
+                value={field.value ?? ''}
+                onChange={(e) => field.onChange(e.target.value === '' ? undefined : Number(e.target.value))}
+              />
+            </>
+          )}
+        />
+
+        <Controller
+          name="nombre_medicamento"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Nombre del medicamento"
+              placeholder="Acetaminofén"
+              variant="outlined"
+              {...field}
+              value={field.value || ''}
+            />
+          )}
+        />
+
+        <Controller
+          name="marca"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Marca"
+              placeholder="Genérico"
+              variant="outlined"
+              {...field}
+              value={field.value || ''}
+            />
+          )}
+        />
+
+        <Controller
+          name="precio"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Precio"
+              type="number"
+              variant="outlined"
+              value={field.value ?? ''}
+              onChange={(e) => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
+            />
+          )}
+        />
+
+        <Controller
+          name="cantidad"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Cantidad"
+              type="number"
+              variant="outlined"
+              value={field.value ?? ''}
+              onChange={(e) => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
+            />
+          )}
+        />
+
+        <Controller
+          name="resetado"
+          control={control}
+          render={({ field }) => (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={field.value ?? false}
+                  onChange={(e) => field.onChange(e.target.checked)}
+                />
+              }
+              label="Resetado"
+            />
+          )}
+        />
+
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={isPending}
+          sx={{ mt: 2, bgcolor: '#2E7D32', '&:hover': { bgcolor: '#1b5e20' } }}
+        >
+          {isPending ? 'Creando…' : 'Crear Inventario'}
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/web/app/pages/admin/components/InventarioTable.tsx
+++ b/web/app/pages/admin/components/InventarioTable.tsx
@@ -1,0 +1,231 @@
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  MenuItem,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import { useGetInventarios, useUpdateInventarioMutation } from '~/lib/api/QueryInventario';
+import type { InventarioUpdate } from '~/types/Inventario';
+
+export function InventarioTable() {
+  const { data: inventarios, isLoading, isError, error } = useGetInventarios('all');
+  const updateMutation = useUpdateInventarioMutation();
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editForm, setEditForm] = useState<InventarioUpdate>({});
+
+  const handleRowClick = (inventario: {
+    id: number;
+    id_maquina: number;
+    nombre_medicamento: string | null;
+    marca: string | null;
+    precio: number | null;
+    cantidad: number | null;
+    resetado: boolean | null;
+  }) => {
+    if (updatingId) return;
+
+    setEditingId(inventario.id);
+    setEditForm({
+      id_maquina: inventario.id_maquina,
+      nombre_medicamento: inventario.nombre_medicamento ?? '',
+      marca: inventario.marca ?? '',
+      precio: inventario.precio,
+      cantidad: inventario.cantidad,
+      resetado: inventario.resetado ?? false,
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditForm({});
+  };
+
+  const handleFieldChange = (field: keyof InventarioUpdate, value: string | boolean | number | null) => {
+    setEditForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSaveEdit = async (id: number) => {
+    setUpdatingId(id);
+    try {
+      await updateMutation.mutateAsync({ id, body: editForm });
+      handleCancelEdit();
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return <Alert severity="error">Error al cargar inventario: {error?.message}</Alert>;
+  }
+
+  if (!inventarios || inventarios.length === 0) {
+    return <Typography>No hay inventario registrado</Typography>;
+  }
+
+  return (
+    <TableContainer component={Paper} sx={{ mt: 3, overflow: 'auto' }}>
+      <Table size="small">
+        <TableHead sx={{ backgroundColor: '#f5f5f5' }}>
+          <TableRow>
+            <TableCell><strong>ID</strong></TableCell>
+            <TableCell><strong>ID Máquina</strong></TableCell>
+            <TableCell><strong>Medicamento</strong></TableCell>
+            <TableCell><strong>Marca</strong></TableCell>
+            <TableCell><strong>Precio</strong></TableCell>
+            <TableCell><strong>Cantidad</strong></TableCell>
+            <TableCell><strong>Resetado</strong></TableCell>
+            <TableCell><strong>Acciones</strong></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {inventarios.map((inventario) => (
+            <TableRow
+              key={inventario.id}
+              hover
+              onClick={() => handleRowClick(inventario)}
+              sx={{ cursor: updatingId ? 'wait' : 'pointer' }}
+            >
+              <TableCell>{inventario.id}</TableCell>
+              <TableCell>
+                {editingId === inventario.id ? (
+                  <TextField
+                    value={editForm.id_maquina ?? ''}
+                    size="small"
+                    type="number"
+                    disabled
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                ) : (
+                  inventario.id_maquina
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === inventario.id ? (
+                  <TextField
+                    value={editForm.nombre_medicamento ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('nombre_medicamento', e.target.value || null)}
+                  />
+                ) : (
+                  inventario.nombre_medicamento || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === inventario.id ? (
+                  <TextField
+                    value={editForm.marca ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('marca', e.target.value || null)}
+                  />
+                ) : (
+                  inventario.marca || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === inventario.id ? (
+                  <TextField
+                    value={editForm.precio ?? ''}
+                    size="small"
+                    type="number"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) =>
+                      handleFieldChange('precio', e.target.value === '' ? null : Number(e.target.value))
+                    }
+                  />
+                ) : (
+                  inventario.precio ?? 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === inventario.id ? (
+                  <TextField
+                    value={editForm.cantidad ?? ''}
+                    size="small"
+                    type="number"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) =>
+                      handleFieldChange('cantidad', e.target.value === '' ? null : Number(e.target.value))
+                    }
+                  />
+                ) : (
+                  inventario.cantidad ?? 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === inventario.id ? (
+                  <TextField
+                    select
+                    value={String(editForm.resetado ?? false)}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('resetado', e.target.value === 'true')}
+                  >
+                    <MenuItem value="true">Sí</MenuItem>
+                    <MenuItem value="false">No</MenuItem>
+                  </TextField>
+                ) : (
+                  inventario.resetado ? 'Sí' : 'No'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === inventario.id ? (
+                  <Box sx={{ display: 'flex', gap: 1 }} onClick={(e) => e.stopPropagation()}>
+                    <Button
+                      variant="contained"
+                      size="small"
+                      onClick={() => handleSaveEdit(inventario.id)}
+                      disabled={updatingId === inventario.id}
+                    >
+                      {updatingId === inventario.id ? <CircularProgress size={20} /> : 'Guardar'}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={handleCancelEdit}
+                      disabled={updatingId === inventario.id}
+                    >
+                      Cancelar
+                    </Button>
+                  </Box>
+                ) : (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRowClick(inventario);
+                    }}
+                  >
+                    Editar
+                  </Button>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/web/app/pages/admin/components/MaquinaForm.tsx
+++ b/web/app/pages/admin/components/MaquinaForm.tsx
@@ -1,0 +1,119 @@
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, Checkbox, FormControlLabel, Stack, TextField, Typography } from '@mui/material';
+import { useCreateMaquinaMutation } from '~/lib/api/QueryMaquina';
+import type { MaquinaCreation } from '~/types/Maquina';
+import { MaquinaCreationSchema } from '~/types/Maquina';
+
+export function MaquinaForm() {
+  const {
+    handleSubmit,
+    formState: { errors },
+    control,
+    reset,
+  } = useForm<MaquinaCreation>({
+    resolver: zodResolver(MaquinaCreationSchema),
+    defaultValues: {
+      ubicacion: '',
+      activo: true,
+      latitud: null,
+      longitud: null,
+    },
+  });
+
+  const { mutate, isPending, isError, error, isSuccess } = useCreateMaquinaMutation();
+
+  const onSubmit = (data: MaquinaCreation) => {
+    mutate(data, {
+      onSuccess: () => reset(),
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Stack spacing={2}>
+        {isSuccess && (
+          <Typography variant="body2" sx={{ color: 'success.main' }}>
+            Máquina creada exitosamente
+          </Typography>
+        )}
+
+        {isError && (
+          <Typography variant="body2" sx={{ color: 'error.main' }}>
+            {error instanceof Error ? error.message : 'Error al crear máquina'}
+          </Typography>
+        )}
+
+        <Controller
+          name="ubicacion"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Ubicación"
+              placeholder="Tienda central"
+              variant="outlined"
+              {...field}
+              value={field.value || ''}
+            />
+          )}
+        />
+
+        <Controller
+          name="latitud"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Latitud"
+              type="number"
+              variant="outlined"
+              value={field.value ?? ''}
+              onChange={(e) => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
+            />
+          )}
+        />
+
+        <Controller
+          name="longitud"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Longitud"
+              type="number"
+              variant="outlined"
+              value={field.value ?? ''}
+              onChange={(e) => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
+            />
+          )}
+        />
+
+        <Controller
+          name="activo"
+          control={control}
+          render={({ field }) => (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={field.value ?? false}
+                  onChange={(e) => field.onChange(e.target.checked)}
+                />
+              }
+              label="Activa"
+            />
+          )}
+        />
+
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={isPending}
+          sx={{ mt: 2, bgcolor: '#2E7D32', '&:hover': { bgcolor: '#1b5e20' } }}
+        >
+          {isPending ? 'Creando…' : 'Crear Máquina'}
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/web/app/pages/admin/components/MaquinaTable.tsx
+++ b/web/app/pages/admin/components/MaquinaTable.tsx
@@ -1,0 +1,200 @@
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  MenuItem,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import { useGetMaquinas, useUpdateMaquinaMutation } from '~/lib/api/QueryMaquina';
+import type { MaquinaUpdate } from '~/types/Maquina';
+
+export function MaquinaTable() {
+  const { data: maquinas, isLoading, isError, error } = useGetMaquinas('all');
+  const updateMutation = useUpdateMaquinaMutation();
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editForm, setEditForm] = useState<MaquinaUpdate>({});
+
+  const handleRowClick = (maquina: {
+    id: number;
+    ubicacion: string | null;
+    activo: boolean | null;
+    latitud: number | null;
+    longitud: number | null;
+  }) => {
+    if (updatingId) return;
+
+    setEditingId(maquina.id);
+    setEditForm({
+      ubicacion: maquina.ubicacion ?? '',
+      activo: maquina.activo ?? true,
+      latitud: maquina.latitud,
+      longitud: maquina.longitud,
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditForm({});
+  };
+
+  const handleFieldChange = (field: keyof MaquinaUpdate, value: string | boolean | number | null) => {
+    setEditForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSaveEdit = async (id: number) => {
+    setUpdatingId(id);
+    try {
+      await updateMutation.mutateAsync({ id, body: editForm });
+      handleCancelEdit();
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return <Alert severity="error">Error al cargar máquinas: {error?.message}</Alert>;
+  }
+
+  if (!maquinas || maquinas.length === 0) {
+    return <Typography>No hay máquinas registradas</Typography>;
+  }
+
+  return (
+    <TableContainer component={Paper} sx={{ mt: 3, overflow: 'auto' }}>
+      <Table size="small">
+        <TableHead sx={{ backgroundColor: '#f5f5f5' }}>
+          <TableRow>
+            <TableCell><strong>ID</strong></TableCell>
+            <TableCell><strong>Ubicación</strong></TableCell>
+            <TableCell><strong>Latitud</strong></TableCell>
+            <TableCell><strong>Longitud</strong></TableCell>
+            <TableCell><strong>Activa</strong></TableCell>
+            <TableCell><strong>Acciones</strong></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {maquinas.map((maquina) => (
+            <TableRow
+              key={maquina.id}
+              hover
+              onClick={() => handleRowClick(maquina)}
+              sx={{ cursor: updatingId ? 'wait' : 'pointer' }}
+            >
+              <TableCell>{maquina.id}</TableCell>
+              <TableCell>
+                {editingId === maquina.id ? (
+                  <TextField
+                    value={editForm.ubicacion ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('ubicacion', e.target.value || null)}
+                  />
+                ) : (
+                  maquina.ubicacion || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === maquina.id ? (
+                  <TextField
+                    value={editForm.latitud ?? ''}
+                    size="small"
+                    type="number"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) =>
+                      handleFieldChange('latitud', e.target.value === '' ? null : Number(e.target.value))
+                    }
+                  />
+                ) : (
+                  maquina.latitud ?? 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === maquina.id ? (
+                  <TextField
+                    value={editForm.longitud ?? ''}
+                    size="small"
+                    type="number"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) =>
+                      handleFieldChange('longitud', e.target.value === '' ? null : Number(e.target.value))
+                    }
+                  />
+                ) : (
+                  maquina.longitud ?? 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === maquina.id ? (
+                  <TextField
+                    select
+                    value={String(editForm.activo ?? true)}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('activo', e.target.value === 'true')}
+                  >
+                    <MenuItem value="true">Sí</MenuItem>
+                    <MenuItem value="false">No</MenuItem>
+                  </TextField>
+                ) : (
+                  maquina.activo ? 'Sí' : 'No'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === maquina.id ? (
+                  <Box sx={{ display: 'flex', gap: 1 }} onClick={(e) => e.stopPropagation()}>
+                    <Button
+                      variant="contained"
+                      size="small"
+                      onClick={() => handleSaveEdit(maquina.id)}
+                      disabled={updatingId === maquina.id}
+                    >
+                      {updatingId === maquina.id ? <CircularProgress size={20} /> : 'Guardar'}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={handleCancelEdit}
+                      disabled={updatingId === maquina.id}
+                    >
+                      Cancelar
+                    </Button>
+                  </Box>
+                ) : (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRowClick(maquina);
+                    }}
+                  >
+                    Editar
+                  </Button>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/web/app/pages/admin/route.tsx
+++ b/web/app/pages/admin/route.tsx
@@ -8,6 +8,10 @@ import { CreateSupabaseUserForm } from './components/CreateSupabaseUserForm';
 import { AccesoTable } from './components/AccesoTable';
 import { UsuarioTable } from './components/UsuarioTable';
 import { ClienteTable } from './components/ClienteTable';
+import { MaquinaForm } from './components/MaquinaForm';
+import { MaquinaTable } from './components/MaquinaTable';
+import { InventarioForm } from './components/InventarioForm';
+import { InventarioTable } from './components/InventarioTable';
 import { useGetAccesos } from '~/lib/api/QueryAcceso';
 import GetSession from '~/lib/GetSession';
 import CustomTabPanel from '~/components/CustomeTabPanel';
@@ -80,6 +84,8 @@ export default function AdminPanel() {
               <Tab label="Crear Acceso" id="admin-tab-1" aria-controls="admin-tabpanel-1" />
               <Tab label="Crear Usuario" id="admin-tab-2" aria-controls="admin-tabpanel-2" />
               <Tab label="Crear Cliente" id="admin-tab-3" aria-controls="admin-tabpanel-3" />
+              <Tab label="Administrar Máquinas" id="admin-tab-4" aria-controls="admin-tabpanel-4" />
+              <Tab label="Inventario de Máquinas" id="admin-tab-5" aria-controls="admin-tabpanel-5" />
             </Tabs>
           </Box>
 
@@ -100,6 +106,16 @@ export default function AdminPanel() {
           <CustomTabPanel value={tabValue} index={3}>
             <ClienteForm />
             <ClienteTable />
+          </CustomTabPanel>
+
+          <CustomTabPanel value={tabValue} index={4}>
+            <MaquinaForm />
+            <MaquinaTable />
+          </CustomTabPanel>
+
+          <CustomTabPanel value={tabValue} index={5}>
+            <InventarioForm />
+            <InventarioTable />
           </CustomTabPanel>
         </Paper>
       </Box>

--- a/web/app/types/Inventario.ts
+++ b/web/app/types/Inventario.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const InventarioSchema = z.object({
+  id: z.number(),
+  id_maquina: z.number(),
+  nombre_medicamento: z.string().nullable(),
+  marca: z.string().nullable(),
+  precio: z.number().nullable(),
+  cantidad: z.number().nullable(),
+  resetado: z.boolean().nullable(),
+});
+
+export const InventarioCreationSchema = z.object({
+  id: z.number().optional(),
+  id_maquina: z.number({ message: 'El ID de la máquina es requerido' }),
+  nombre_medicamento: z.string().nullable().optional(),
+  marca: z.string().nullable().optional(),
+  precio: z.number().nullable().optional(),
+  cantidad: z.number().nullable().optional(),
+  resetado: z.boolean().optional(),
+});
+
+export const InventarioUpdateSchema = InventarioCreationSchema.partial();
+
+export type Inventario = z.infer<typeof InventarioSchema>;
+export type InventarioCreation = z.infer<typeof InventarioCreationSchema>;
+export type InventarioUpdate = z.infer<typeof InventarioUpdateSchema>;

--- a/web/app/types/Maquina.ts
+++ b/web/app/types/Maquina.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const MaquinaSchema = z.object({
+  id: z.number(),
+  ubicacion: z.string().nullable(),
+  activo: z.boolean().nullable(),
+  latitud: z.number().nullable(),
+  longitud: z.number().nullable(),
+});
+
+export const MaquinaCreationSchema = z.object({
+  id: z.number().optional(),
+  ubicacion: z.string().nullable().optional(),
+  activo: z.boolean().optional(),
+  latitud: z.number().nullable().optional(),
+  longitud: z.number().nullable().optional(),
+});
+
+export const MaquinaUpdateSchema = MaquinaCreationSchema.partial();
+
+export type Maquina = z.infer<typeof MaquinaSchema>;
+export type MaquinaCreation = z.infer<typeof MaquinaCreationSchema>;
+export type MaquinaUpdate = z.infer<typeof MaquinaUpdateSchema>;


### PR DESCRIPTION
This pull request introduces new React components and API hooks to manage "Inventario" (inventory) and "Maquina" (machine) entities in the admin interface. It provides full CRUD (Create, Read, Update) functionality for both resources, leveraging React Query for data fetching and mutation, and React Hook Form with Zod for form validation. The UI allows admins to view, create, and edit records with inline editing and proper feedback for loading and errors.

**API Layer Enhancements:**

- Added custom React Query hooks for "Inventario" and "Maquina" to handle create, update, and fetch operations, with automatic cache invalidation on mutations. (`QueryInventario.ts`, `QueryMaquina.ts`) [[1]](diffhunk://#diff-86802efadf67f6604d7c04d3f412f5c0b8379487ae2fe48d4a88991a13db4b2fR1-R50) [[2]](diffhunk://#diff-571633876c147811f62e3b4dbfa25b138e4f547c9bdd203afe2090453cb74b21R1-R50)

**Admin UI Components:**

- **Forms:**
  - Created `InventarioForm` and `MaquinaForm` components for adding new inventory and machine records, using React Hook Form and Zod for validation and MUI for UI elements. (`InventarioForm.tsx`, `MaquinaForm.tsx`) [[1]](diffhunk://#diff-2b719d06004dc2f56ebb4959166fd7fc84bbdd5c4382af430cc051f6c5ec6aacR1-R158) [[2]](diffhunk://#diff-4bdd6c94c7db778f30c798b49c7a2052ce00873af67acb7c81f5e8f1658ac552R1-R119)

- **Tables:**
  - Implemented `InventarioTable` and `MaquinaTable` components to display, inline-edit, and update existing records. These tables handle loading, error, and empty states, and provide user feedback on actions. (`InventarioTable.tsx`, `MaquinaTable.tsx`) [[1]](diffhunk://#diff-7a2d2cf5824d608f966956e7af2aa4df6b09a37d6ed51c80e54c3410b224c00bR1-R231) [[2]](diffhunk://#diff-284bfc470c3b2a7fac15588821d53f24033ad6014a34eff17cfc601340571b5cR1-R200)

**State and UX Improvements:**

- Inline editing is supported in tables, with row-level editing, cancel/save controls, and loading indicators during update operations. Error and success messages are displayed for user feedback. [[1]](diffhunk://#diff-7a2d2cf5824d608f966956e7af2aa4df6b09a37d6ed51c80e54c3410b224c00bR1-R231) [[2]](diffhunk://#diff-284bfc470c3b2a7fac15588821d53f24033ad6014a34eff17cfc601340571b5cR1-R200) [[3]](diffhunk://#diff-2b719d06004dc2f56ebb4959166fd7fc84bbdd5c4382af430cc051f6c5ec6aacR1-R158) [[4]](diffhunk://#diff-4bdd6c94c7db778f30c798b49c7a2052ce00873af67acb7c81f5e8f1658ac552R1-R119)