### PR TITLE
32 feat nuevos tabs administrativo

### DIFF
--- a/api/src/controllers/SessionControll.ts
+++ b/api/src/controllers/SessionControll.ts
@@ -39,10 +39,14 @@ export async function SingUp(request: Request, response: Response) {
 
 export async function RefreshToken(request: Request, response: Response) {
     try {
-        const authHeader = request.headers.authorization;
-        const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+        // const authHeader = request.headers.authorization;
+        // const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+        // if (!token) {
+        //     return response.status(400).json({ error: 'Token Bearer requerido' });
+        // }
+        const { refresh_token: token } = request.body;
         if (!token) {
-            return response.status(400).json({ error: 'Token Bearer requerido' });
+            return response.status(400).json({ error: 'Token de refresco requerido' });
         }
         const { data, error } = await supabase.auth.refreshSession({ refresh_token: token });
         if (error || !data.session) {

--- a/api/src/middleware/validateCliente.ts
+++ b/api/src/middleware/validateCliente.ts
@@ -47,8 +47,7 @@ export const validateClienteCreation = [
   body("id_acceso")
     .trim()
     .notEmpty()
-    .isNumeric()
-    .withMessage('el id_acceso es requerido y debe ser un número'),
+    .withMessage('el id_acceso es requerido'),
 ];
 
 // Middleware para manejar errores de validación

--- a/web/app/components/CustomeSelectQuery.tsx
+++ b/web/app/components/CustomeSelectQuery.tsx
@@ -1,0 +1,44 @@
+import { InputLabel, MenuItem, Select } from "@mui/material";
+import { useQueryAll } from "~/lib/api/QueryAll";
+
+interface CustomSelectQueryProps {
+  onChange: (value: any) => void;
+  labelID?: string;
+  label?: string;
+  value?: any;
+  endpoint?: string;
+  labelSelector?: string;
+  secondaryLabelSelector?: string;
+  valueSelector?: string;
+}
+
+export default function CustomeSelectQuery(props: CustomSelectQueryProps) {
+  const { onChange, labelID, label, value, endpoint, labelSelector, secondaryLabelSelector, valueSelector } = props;
+  const { All } = useQueryAll(endpoint || '');
+  const { data } = All;
+  return(
+    <>
+    <InputLabel id={labelID}>{label}</InputLabel>
+      <Select
+        labelId={labelID}
+        value={value}
+        onChange={onChange}
+        
+      >
+        <MenuItem value="">
+          <em>None</em>
+        </MenuItem>
+        {data?.map((item: any) => (
+          <MenuItem key={item.id} value={valueSelector ? item[valueSelector] : item.id}>
+            {labelSelector ? <><strong>{labelSelector}:</strong> {item[labelSelector]} </> : "label"}
+            <br/>
+            {secondaryLabelSelector && 
+              item[secondaryLabelSelector]
+            }
+          </MenuItem>
+        ))}
+
+      </Select>
+    </>
+  )
+}

--- a/web/app/lib/api/QueryAll.ts
+++ b/web/app/lib/api/QueryAll.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiJson } from "../apiClient";
+
+
+export function useQueryAll (endpoint:string) {
+  const All = useQuery({
+    queryKey: [`${endpoint}-all`],
+    queryFn: async (): Promise<any[]> => apiJson(`${endpoint}/all`, {
+      method: 'GET',
+      auth: true,
+    }),
+  });
+  return {All};
+}

--- a/web/app/lib/api/QueryDosis.ts
+++ b/web/app/lib/api/QueryDosis.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { Dosis, DosisCreation, DosisUpdate } from '~/types/Dosis';
+import { apiJson } from '../apiClient';
+
+export const useCreateDosisMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (form: DosisCreation): Promise<Dosis> => {
+      return apiJson<Dosis>('/dosis', {
+        method: 'POST',
+        body: form,
+        auth: true,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['dosis'] });
+    },
+  });
+};
+
+export const useUpdateDosisMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: number; body: DosisUpdate }) => {
+      return apiJson<Dosis>(`/dosis/${id}`, {
+        method: 'PUT',
+        body,
+        auth: true,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['dosis'] });
+    },
+  });
+};
+
+export const useGetDosis = (id: string, enabled: boolean = true) => {
+  return useQuery({
+    queryKey: ['dosis', id],
+    queryFn: async (): Promise<Dosis[]> => {
+      return apiJson<Dosis[]>(`/dosis/${id}`, {
+        method: 'GET',
+        auth: true,
+      });
+    },
+    enabled,
+  });
+};

--- a/web/app/lib/api/QueryReceta.ts
+++ b/web/app/lib/api/QueryReceta.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { Receta, RecetaCreation, RecetaUpdate } from '~/types/receta';
+import { apiJson } from '../apiClient';
+
+export const useCreateRecetaMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (form: RecetaCreation): Promise<Receta> => {
+      return apiJson<Receta>('/recetas', {
+        method: 'POST',
+        body: form,
+        auth: true,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['recetas'] });
+    },
+  });
+};
+
+export const useUpdateRecetaMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: number; body: RecetaUpdate }) => {
+      return apiJson<Receta>(`/recetas/${id}`, {
+        method: 'PUT',
+        body,
+        auth: true,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['recetas'] });
+    },
+  });
+};
+
+export const useGetRecetas = (id: string, enabled: boolean = true) => {
+  return useQuery({
+    queryKey: ['recetas', id],
+    queryFn: async (): Promise<Receta[]> => {
+      return apiJson<Receta[]>(`/recetas/${id}`, {
+        method: 'GET',
+        auth: true,
+      });
+    },
+    enabled,
+  });
+};

--- a/web/app/lib/apiClient.ts
+++ b/web/app/lib/apiClient.ts
@@ -75,6 +75,7 @@ export async function apiJson<T>(path: string, options: ApiFetchOptions = {}): P
 
     if (refreshResponse?.session?.access_token) {
       await saveCookieStoreValue("token", refreshResponse.session.access_token);
+      await saveCookieStoreValue("refresh_token", refreshResponse.session.refresh_token);
       return apiJson(path, options);
     }
   }

--- a/web/app/pages/admin/components/ClienteForm.tsx
+++ b/web/app/pages/admin/components/ClienteForm.tsx
@@ -146,10 +146,9 @@ export function ClienteForm() {
               <TextField
                 fullWidth
                 label="ID de Acceso"
-                type="number"
                 variant="outlined"
                 value={field.value ?? ''}
-                onChange={(e) => field.onChange(Number(e.target.value))}
+                onChange={(e) => field.onChange(e.target.value)}
               />
             </>
           )}

--- a/web/app/pages/admin/components/ClienteForm.tsx
+++ b/web/app/pages/admin/components/ClienteForm.tsx
@@ -5,6 +5,7 @@ import type { ClienteCreation } from '~/types/cliente';
 import { ClienteCreationSchema } from '~/types/cliente';
 import { useCreateClienteMutation } from '~/lib/Query';
 import RefreshQuery from '~/lib/RefreshQuery';
+import CustomeSelectQuery from '~/components/CustomeSelectQuery';
 
 export function ClienteForm() {
   const {
@@ -143,12 +144,15 @@ export function ClienteForm() {
                   {errors.id_acceso.message}
                 </Typography>
               )}
-              <TextField
-                fullWidth
-                label="ID de Acceso"
-                variant="outlined"
+              <CustomeSelectQuery
+                endpoint='accesos'
+                labelID='acceso1'
+                label="ID Acceso"
+                labelSelector='id'
+                secondaryLabelSelector='correo'
+                valueSelector='id'
                 value={field.value ?? ''}
-                onChange={(e) => field.onChange(e.target.value)}
+                onChange={field.onChange}
               />
             </>
           )}

--- a/web/app/pages/admin/components/DosisForm.tsx
+++ b/web/app/pages/admin/components/DosisForm.tsx
@@ -1,0 +1,127 @@
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, Stack, TextField, Typography } from '@mui/material';
+import { useCreateDosisMutation } from '~/lib/api/QueryDosis';
+import type { DosisCreation } from '~/types/Dosis';
+import { DosisCreationSchema } from '~/types/Dosis';
+
+export function DosisForm() {
+  const {
+    handleSubmit,
+    formState: { errors },
+    control,
+    reset,
+  } = useForm<DosisCreation>({
+    resolver: zodResolver(DosisCreationSchema),
+    defaultValues: {
+      id_medicamento: null,
+      id_receta: undefined,
+      cantidad: null,
+      instrucciones: '',
+    },
+  });
+
+  const { mutate, isPending, isError, error, isSuccess } = useCreateDosisMutation();
+
+  const onSubmit = (data: DosisCreation) => {
+    mutate(data, {
+      onSuccess: () => reset(),
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Stack spacing={2}>
+        {isSuccess && (
+          <Typography variant="body2" sx={{ color: 'success.main' }}>
+            Dosis creada exitosamente
+          </Typography>
+        )}
+
+        {isError && (
+          <Typography variant="body2" sx={{ color: 'error.main' }}>
+            {error instanceof Error ? error.message : 'Error al crear dosis'}
+          </Typography>
+        )}
+
+        <Controller
+          name="id_medicamento"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="ID del medicamento"
+              type="number"
+              variant="outlined"
+              value={field.value ?? ''}
+              onChange={(e) => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
+            />
+          )}
+        />
+
+        <Controller
+          name="id_receta"
+          control={control}
+          render={({ field }) => (
+            <>
+              {errors.id_receta && (
+                <Typography variant="body2" sx={{ color: 'error.main' }}>
+                  {errors.id_receta.message}
+                </Typography>
+              )}
+              <TextField
+                fullWidth
+                label="ID de la receta"
+                type="number"
+                variant="outlined"
+                value={field.value ?? ''}
+                onChange={(e) => field.onChange(e.target.value === '' ? undefined : Number(e.target.value))}
+              />
+            </>
+          )}
+        />
+
+        <Controller
+          name="cantidad"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Cantidad"
+              type="number"
+              variant="outlined"
+              value={field.value ?? ''}
+              onChange={(e) => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
+            />
+          )}
+        />
+
+        <Controller
+          name="instrucciones"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Instrucciones"
+              placeholder="Tomar después de las comidas"
+              variant="outlined"
+              multiline
+              rows={3}
+              {...field}
+              value={field.value || ''}
+            />
+          )}
+        />
+
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={isPending}
+          sx={{ mt: 2, bgcolor: '#2E7D32', '&:hover': { bgcolor: '#1b5e20' } }}
+        >
+          {isPending ? 'Creando…' : 'Crear Dosis'}
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/web/app/pages/admin/components/DosisTable.tsx
+++ b/web/app/pages/admin/components/DosisTable.tsx
@@ -1,0 +1,192 @@
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import { useGetDosis, useUpdateDosisMutation } from '~/lib/api/QueryDosis';
+import type { DosisUpdate } from '~/types/Dosis';
+
+export function DosisTable() {
+  const { data: dosis, isLoading, isError, error } = useGetDosis('all');
+  const updateMutation = useUpdateDosisMutation();
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editForm, setEditForm] = useState<DosisUpdate>({});
+
+  const handleRowClick = (dosisItem: {
+    id: number;
+    id_medicamento: number | null;
+    id_receta: number;
+    cantidad: number | null;
+    instrucciones: string | null;
+  }) => {
+    if (updatingId) return;
+
+    setEditingId(dosisItem.id);
+    setEditForm({
+      id_medicamento: dosisItem.id_medicamento,
+      id_receta: dosisItem.id_receta,
+      cantidad: dosisItem.cantidad,
+      instrucciones: dosisItem.instrucciones ?? '',
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditForm({});
+  };
+
+  const handleFieldChange = (field: keyof DosisUpdate, value: string | number | null) => {
+    setEditForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSaveEdit = async (id: number) => {
+    setUpdatingId(id);
+    try {
+      await updateMutation.mutateAsync({ id, body: editForm });
+      handleCancelEdit();
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return <Alert severity="error">Error al cargar dosis: {error?.message}</Alert>;
+  }
+
+  if (!dosis || dosis.length === 0) {
+    return <Typography>No hay dosis registradas</Typography>;
+  }
+
+  return (
+    <TableContainer component={Paper} sx={{ mt: 3, overflow: 'auto' }}>
+      <Table size="small">
+        <TableHead sx={{ backgroundColor: '#f5f5f5' }}>
+          <TableRow>
+            <TableCell><strong>ID</strong></TableCell>
+            <TableCell><strong>ID Medicamento</strong></TableCell>
+            <TableCell><strong>ID Receta</strong></TableCell>
+            <TableCell><strong>Cantidad</strong></TableCell>
+            <TableCell><strong>Instrucciones</strong></TableCell>
+            <TableCell><strong>Acciones</strong></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {dosis.map((dosisItem) => (
+            <TableRow
+              key={dosisItem.id}
+              hover
+              onClick={() => handleRowClick(dosisItem)}
+              sx={{ cursor: updatingId ? 'wait' : 'pointer' }}
+            >
+              <TableCell>{dosisItem.id}</TableCell>
+              <TableCell>
+                {editingId === dosisItem.id ? (
+                  <TextField
+                    value={editForm.id_medicamento ?? ''}
+                    size="small"
+                    type="number"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('id_medicamento', e.target.value === '' ? null : Number(e.target.value))}
+                  />
+                ) : (
+                  dosisItem.id_medicamento ?? 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === dosisItem.id ? (
+                  <TextField
+                    value={editForm.id_receta ?? ''}
+                    size="small"
+                    type="number"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('id_receta', Number(e.target.value))}
+                  />
+                ) : (
+                  dosisItem.id_receta
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === dosisItem.id ? (
+                  <TextField
+                    value={editForm.cantidad ?? ''}
+                    size="small"
+                    type="number"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('cantidad', e.target.value === '' ? null : Number(e.target.value))}
+                  />
+                ) : (
+                  dosisItem.cantidad ?? 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === dosisItem.id ? (
+                  <TextField
+                    value={editForm.instrucciones ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('instrucciones', e.target.value || null)}
+                  />
+                ) : (
+                  dosisItem.instrucciones || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === dosisItem.id ? (
+                  <Box sx={{ display: 'flex', gap: 1 }} onClick={(e) => e.stopPropagation()}>
+                    <Button
+                      variant="contained"
+                      size="small"
+                      onClick={() => handleSaveEdit(dosisItem.id)}
+                      disabled={updatingId === dosisItem.id}
+                    >
+                      {updatingId === dosisItem.id ? <CircularProgress size={20} /> : 'Guardar'}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={handleCancelEdit}
+                      disabled={updatingId === dosisItem.id}
+                    >
+                      Cancelar
+                    </Button>
+                  </Box>
+                ) : (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRowClick(dosisItem);
+                    }}
+                  >
+                    Editar
+                  </Button>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/web/app/pages/admin/components/RecetaForm.tsx
+++ b/web/app/pages/admin/components/RecetaForm.tsx
@@ -1,0 +1,190 @@
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, Stack, TextField, Typography } from '@mui/material';
+import { useCreateRecetaMutation } from '~/lib/api/QueryReceta';
+import type { RecetaCreation } from '~/types/receta';
+import { RecetaCreationSchema } from '~/types/receta';
+
+export function RecetaForm() {
+  const {
+    handleSubmit,
+    formState: { errors },
+    control,
+    reset,
+  } = useForm({
+    resolver: zodResolver(RecetaCreationSchema),
+    defaultValues: {
+      id_cliente: undefined,
+      doctor_remitente: '',
+      ruc_doctor_remitente: '',
+      hospital_remitente: '',
+      telefono_hospital: '',
+      correo: '',
+      codigo: null,
+      fecha: null,
+    },
+  });
+
+  const { mutate, isPending, isError, error, isSuccess } = useCreateRecetaMutation();
+
+  const onSubmit = (data: RecetaCreation) => {
+    mutate(data, {
+      onSuccess: () => reset(),
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Stack spacing={2}>
+        {isSuccess && (
+          <Typography variant="body2" sx={{ color: 'success.main' }}>
+            Receta creada exitosamente
+          </Typography>
+        )}
+
+        {isError && (
+          <Typography variant="body2" sx={{ color: 'error.main' }}>
+            {error instanceof Error ? error.message : 'Error al crear receta'}
+          </Typography>
+        )}
+
+        <Controller
+          name="id_cliente"
+          control={control}
+          render={({ field }) => (
+            <>
+              {errors.id_cliente && (
+                <Typography variant="body2" sx={{ color: 'error.main' }}>
+                  {errors.id_cliente.message}
+                </Typography>
+              )}
+              <TextField
+                fullWidth
+                label="ID del cliente"
+                type="number"
+                variant="outlined"
+                value={field.value ?? ''}
+                onChange={(e) => field.onChange(e.target.value === '' ? undefined : Number(e.target.value))}
+              />
+            </>
+          )}
+        />
+
+        <Controller
+          name="doctor_remitente"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Doctor remitente"
+              placeholder="Dr. Juan Pérez"
+              variant="outlined"
+              {...field}
+              value={field.value || ''}
+            />
+          )}
+        />
+
+        <Controller
+          name="ruc_doctor_remitente"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="RUC doctor remitente"
+              placeholder="123456789"
+              variant="outlined"
+              {...field}
+              value={field.value || ''}
+            />
+          )}
+        />
+
+        <Controller
+          name="hospital_remitente"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Hospital remitente"
+              placeholder="Hospital Central"
+              variant="outlined"
+              {...field}
+              value={field.value || ''}
+            />
+          )}
+        />
+
+        <Controller
+          name="telefono_hospital"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Teléfono del hospital"
+              placeholder="0999999999"
+              variant="outlined"
+              {...field}
+              value={field.value || ''}
+            />
+          )}
+        />
+
+        <Controller
+          name="correo"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Correo"
+              type="email"
+              placeholder="doctor@hospital.com"
+              variant="outlined"
+              value={field.value || ''}
+              onChange={(e) => field.onChange(e.target.value || null)}
+            />
+          )}
+        />
+
+        <Controller
+          name="codigo"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Código"
+              type="number"
+              variant="outlined"
+              value={field.value ?? ''}
+              onChange={(e) => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
+            />
+          )}
+        />
+
+        <Controller
+          name="fecha"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              fullWidth
+              label="Fecha"
+              type="date"
+              variant="outlined"
+              value={field.value ? new Date(field.value).toISOString().slice(0, 10) : ''}
+              onChange={(e) => field.onChange(e.target.value ? new Date(e.target.value) : null)}
+            />
+          )}
+        />
+
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={isPending}
+          sx={{ mt: 2, bgcolor: '#2E7D32', '&:hover': { bgcolor: '#1b5e20' } }}
+        >
+          {isPending ? 'Creando…' : 'Crear Receta'}
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/web/app/pages/admin/components/RecetaTable.tsx
+++ b/web/app/pages/admin/components/RecetaTable.tsx
@@ -1,0 +1,259 @@
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import { useGetRecetas, useUpdateRecetaMutation } from '~/lib/api/QueryReceta';
+import type { RecetaUpdate } from '~/types/receta';
+
+function formatDateForInput(value: string | Date | null | undefined) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toISOString().slice(0, 10);
+}
+
+export function RecetaTable() {
+  const { data: recetas, isLoading, isError, error } = useGetRecetas('all');
+  const updateMutation = useUpdateRecetaMutation();
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editForm, setEditForm] = useState<RecetaUpdate>({});
+
+  const handleRowClick = (receta: {
+    id: number;
+    id_cliente: number;
+    doctor_remitente: string | null;
+    ruc_doctor_remitente: string | null;
+    hospital_remitente: string | null;
+    telefono_hospital: string | null;
+    correo: string | null;
+    codigo: number | null;
+    fecha: string | Date | null;
+  }) => {
+    if (updatingId) return;
+
+    setEditingId(receta.id);
+    setEditForm({
+      id_cliente: receta.id_cliente,
+      doctor_remitente: receta.doctor_remitente ?? '',
+      ruc_doctor_remitente: receta.ruc_doctor_remitente ?? '',
+      hospital_remitente: receta.hospital_remitente ?? '',
+      telefono_hospital: receta.telefono_hospital ?? '',
+      correo: receta.correo ?? '',
+      codigo: receta.codigo,
+      fecha: receta.fecha ? new Date(receta.fecha) : null,
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditForm({});
+  };
+
+  const handleFieldChange = (field: keyof RecetaUpdate, value: string | number | Date | null) => {
+    setEditForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSaveEdit = async (id: number) => {
+    setUpdatingId(id);
+    try {
+      await updateMutation.mutateAsync({ id, body: editForm });
+      handleCancelEdit();
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return <Alert severity="error">Error al cargar recetas: {error?.message}</Alert>;
+  }
+
+  if (!recetas || recetas.length === 0) {
+    return <Typography>No hay recetas registradas</Typography>;
+  }
+
+  return (
+    <TableContainer component={Paper} sx={{ mt: 3, overflow: 'auto' }}>
+      <Table size="small">
+        <TableHead sx={{ backgroundColor: '#f5f5f5' }}>
+          <TableRow>
+            <TableCell><strong>ID</strong></TableCell>
+            <TableCell><strong>ID Cliente</strong></TableCell>
+            <TableCell><strong>Doctor</strong></TableCell>
+            <TableCell><strong>RUC Doctor</strong></TableCell>
+            <TableCell><strong>Hospital</strong></TableCell>
+            <TableCell><strong>Teléfono</strong></TableCell>
+            <TableCell><strong>Correo</strong></TableCell>
+            <TableCell><strong>Código</strong></TableCell>
+            <TableCell><strong>Fecha</strong></TableCell>
+            <TableCell><strong>Acciones</strong></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {recetas.map((receta) => (
+            <TableRow
+              key={receta.id}
+              hover
+              onClick={() => handleRowClick(receta)}
+              sx={{ cursor: updatingId ? 'wait' : 'pointer' }}
+            >
+              <TableCell>{receta.id}</TableCell>
+              <TableCell>
+                {editingId === receta.id ? (
+                  <TextField
+                    value={editForm.id_cliente ?? ''}
+                    size="small"
+                    type="number"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('id_cliente', Number(e.target.value))}
+                  />
+                ) : (
+                  receta.id_cliente
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === receta.id ? (
+                  <TextField
+                    value={editForm.doctor_remitente ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('doctor_remitente', e.target.value || null)}
+                  />
+                ) : (
+                  receta.doctor_remitente || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === receta.id ? (
+                  <TextField
+                    value={editForm.ruc_doctor_remitente ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('ruc_doctor_remitente', e.target.value || null)}
+                  />
+                ) : (
+                  receta.ruc_doctor_remitente || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === receta.id ? (
+                  <TextField
+                    value={editForm.hospital_remitente ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('hospital_remitente', e.target.value || null)}
+                  />
+                ) : (
+                  receta.hospital_remitente || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === receta.id ? (
+                  <TextField
+                    value={editForm.telefono_hospital ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('telefono_hospital', e.target.value || null)}
+                  />
+                ) : (
+                  receta.telefono_hospital || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === receta.id ? (
+                  <TextField
+                    value={editForm.correo ?? ''}
+                    size="small"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('correo', e.target.value || null)}
+                  />
+                ) : (
+                  receta.correo || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === receta.id ? (
+                  <TextField
+                    value={editForm.codigo ?? ''}
+                    size="small"
+                    type="number"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('codigo', e.target.value === '' ? null : Number(e.target.value))}
+                  />
+                ) : (
+                  receta.codigo ?? 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === receta.id ? (
+                  <TextField
+                    value={formatDateForInput(editForm.fecha)}
+                    size="small"
+                    type="date"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('fecha', e.target.value ? new Date(e.target.value) : null)}
+                  />
+                ) : (
+                  formatDateForInput(receta.fecha) || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === receta.id ? (
+                  <Box sx={{ display: 'flex', gap: 1 }} onClick={(e) => e.stopPropagation()}>
+                    <Button
+                      variant="contained"
+                      size="small"
+                      onClick={() => handleSaveEdit(receta.id)}
+                      disabled={updatingId === receta.id}
+                    >
+                      {updatingId === receta.id ? <CircularProgress size={20} /> : 'Guardar'}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={handleCancelEdit}
+                      disabled={updatingId === receta.id}
+                    >
+                      Cancelar
+                    </Button>
+                  </Box>
+                ) : (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRowClick(receta);
+                    }}
+                  >
+                    Editar
+                  </Button>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/web/app/pages/admin/components/UsuarioForm.tsx
+++ b/web/app/pages/admin/components/UsuarioForm.tsx
@@ -5,6 +5,7 @@ import type { UsuarioCreation } from '~/types/Usuario';
 import { UsuarioCreationSchema } from '~/types/Usuario';
 import { useCreateUsuarioMutation } from '~/lib/Query';
 import RefreshQuery from '~/lib/RefreshQuery';
+import CustomeSelectQuery from '~/components/CustomeSelectQuery';
 
 export function UsuarioForm() {
   const {
@@ -140,14 +141,16 @@ export function UsuarioForm() {
           name="id_acceso"
           control={control}
           render={({ field }) => (
-            <TextField
-              fullWidth
-              label="ID de Acceso"
-              placeholder="123456789"
-              variant="outlined"
-              {...field}
-              value={field.value || ''}
-            />
+          <CustomeSelectQuery
+                endpoint='accesos'
+                labelID='acceso'
+                label="ID Acceso"
+                labelSelector='id'
+                secondaryLabelSelector='correo'
+                valueSelector='id'
+                value={field.value ?? ''}
+                onChange={field.onChange}
+              />
           )}
         />
 

--- a/web/app/pages/admin/route.tsx
+++ b/web/app/pages/admin/route.tsx
@@ -12,6 +12,10 @@ import { MaquinaForm } from './components/MaquinaForm';
 import { MaquinaTable } from './components/MaquinaTable';
 import { InventarioForm } from './components/InventarioForm';
 import { InventarioTable } from './components/InventarioTable';
+import { RecetaForm } from './components/RecetaForm';
+import { RecetaTable } from './components/RecetaTable';
+import { DosisForm } from './components/DosisForm';
+import { DosisTable } from './components/DosisTable';
 import { useGetAccesos } from '~/lib/api/QueryAcceso';
 import GetSession from '~/lib/GetSession';
 import CustomTabPanel from '~/components/CustomeTabPanel';
@@ -84,6 +88,7 @@ export default function AdminPanel() {
               <Tab label="Crear Cliente" id="admin-tab-3" aria-controls="admin-tabpanel-3" />
               <Tab label="Administrar Máquinas" id="admin-tab-4" aria-controls="admin-tabpanel-4" />
               <Tab label="Inventario de Máquinas" id="admin-tab-5" aria-controls="admin-tabpanel-5" />
+              <Tab label="Recetas y Dosis" id="admin-tab-6" aria-controls="admin-tabpanel-6" />
             </Tabs>
           </Box>
 
@@ -114,6 +119,13 @@ export default function AdminPanel() {
           <CustomTabPanel value={tabValue} index={5}>
             <InventarioForm />
             <InventarioTable />
+          </CustomTabPanel>
+
+          <CustomTabPanel value={tabValue} index={6}>
+            <RecetaForm />
+            <RecetaTable />
+            <DosisForm />
+            <DosisTable />
           </CustomTabPanel>
         </Paper>
       </Box>

--- a/web/app/types/Dosis.ts
+++ b/web/app/types/Dosis.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const DosisSchema = z.object({
+  id: z.number(),
+  id_medicamento: z.number().nullable(),
+  id_receta: z.number(),
+  cantidad: z.number().nullable(),
+  instrucciones: z.string().nullable(),
+});
+
+export const DosisCreationSchema = z.object({
+  id: z.number().optional(),
+  id_medicamento: z.number().nullable().optional(),
+  id_receta: z.number({ message: 'El ID de la receta es requerido' }),
+  cantidad: z.number().nullable().optional(),
+  instrucciones: z.string().nullable().optional(),
+});
+
+export const DosisUpdateSchema = DosisCreationSchema.partial();
+
+export type Dosis = z.infer<typeof DosisSchema>;
+export type DosisCreation = z.infer<typeof DosisCreationSchema>;
+export type DosisUpdate = z.infer<typeof DosisUpdateSchema>;

--- a/web/app/types/cliente.ts
+++ b/web/app/types/cliente.ts
@@ -10,7 +10,7 @@ export const ClienteSchema = z.object({
   asegurado: z.boolean(),
   verificado: z.boolean(),
   sexo: z.string().nullable(),
-  id_acceso: z.number(),
+  id_acceso: z.string(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
 });
@@ -24,7 +24,7 @@ export const ClienteCreationSchema = z.object({
   asegurado: z.boolean().optional().default(false),
   verificado: z.boolean().optional().default(false),
   sexo: z.string().nullable().optional(),
-  id_acceso: z.number(),
+  id_acceso: z.string(),
   createdAt: z.coerce.date().optional(),
   updatedAt: z.coerce.date().optional(),
 });

--- a/web/app/types/receta.ts
+++ b/web/app/types/receta.ts
@@ -23,7 +23,7 @@ export const RecetaCreationSchema = z.object({
   telefono_hospital: z.string().nullable().optional(),
   correo: z.email().nullable().optional(),
   codigo: z.number().nullable().optional(),
-  fecha: z.coerce.date().nullable().optional(),
+  fecha: z.date().nullable().optional(),
 });
 
 // Schema para actualización (todos los campos opcionales excepto id)


### PR DESCRIPTION
This pull request introduces significant enhancements to the medication and prescription management features in the application, focusing on CRUD operations for "Dosis" (doses) and "Receta" (prescriptions). It adds new React components for creating and editing these entities, implements reusable API hooks for data fetching and mutations, and improves form usability by introducing a custom select component. Additionally, there are some backend and validation adjustments to support these changes.

**Key changes include:**

### Dosis (Dose) Management

* Added `DosisForm` and `DosisTable` components for creating and editing doses, including inline editing within the table and feedback for user actions. (`web/app/pages/admin/components/DosisForm.tsx`, `web/app/pages/admin/components/DosisTable.tsx`) [[1]](diffhunk://#diff-82bd66bb67db8b6786d99a3a77e23e28127c8b36d64e81b0ad6c98ddf2dd0ccbR1-R127) [[2]](diffhunk://#diff-38d2dd8285184730fb18c1550826a0020d5aee6300f8aa731a2653ab41b6fbd7R1-R192)
* Implemented new API hooks for dose creation, update, and retrieval, leveraging React Query for cache management and reactivity. (`web/app/lib/api/QueryDosis.ts`)

### Receta (Prescription) Management

* Added a `RecetaForm` component for creating prescriptions with validation and user feedback. (`web/app/pages/admin/components/RecetaForm.tsx`)
* Implemented new API hooks for prescription creation, update, and retrieval, using React Query. (`web/app/lib/api/QueryReceta.ts`)

### Form Usability and Data Fetching

* Introduced a reusable `CustomeSelectQuery` component for dynamic select inputs populated from API endpoints, and integrated it into the client creation form for selecting access IDs. (`web/app/components/CustomeSelectQuery.tsx`, `web/app/pages/admin/components/ClienteForm.tsx`) [[1]](diffhunk://#diff-571b9f35e6ecbf117667005d9b7d1f1b89e2595b2b9b989a01cb9c2fbecf97d2R1-R44) [[2]](diffhunk://#diff-eb9ebf4adf67dbfcbb2a5d044262b237ce464397651d1732a742f36236aafc3bR8) [[3]](diffhunk://#diff-eb9ebf4adf67dbfcbb2a5d044262b237ce464397651d1732a742f36236aafc3bL146-R155)
* Added a generic `useQueryAll` hook for fetching all items from a given endpoint. (`web/app/lib/api/QueryAll.ts`)

### Backend and Validation Adjustments

* Modified the refresh token logic to accept the refresh token from the request body instead of the Authorization header, improving compatibility with frontend changes. (`api/src/controllers/SessionControll.ts`)
* Updated client creation validation to remove the numeric requirement for `id_acceso`, aligning with the new select input. (`api/src/middleware/validateCliente.ts`)
* Ensured the refresh token is saved in the cookie store after refreshing the session. (`web/app/lib/apiClient.ts`)