### PR TITLE
feat: add sorting functionality for 'Asegurado' column in PatientsTable

### DIFF
--- a/web/app/pages/dashboard/components/PatientsTable.tsx
+++ b/web/app/pages/dashboard/components/PatientsTable.tsx
@@ -101,6 +101,13 @@ export function PatientsTable({
                   onSort={onSort}
                 />
                 <SortCell
+                  label="Asegurado"
+                  field="asegurado"
+                  sortKey={sortKey}
+                  sortDir={sortDir}
+                  onSort={onSort}
+                />
+                <SortCell
                   label="Sexo"
                   field="sexo"
                   sortKey={sortKey}


### PR DESCRIPTION
This pull request adds a new sortable column to the patients table in the dashboard. The most important change is the addition of the "Asegurado" field, allowing users to sort patients by their insurance status.

Table column update:

* Added a `SortCell` for the "Asegurado" field to the `PatientsTable`, enabling sorting by insurance status.