### PR TITLE
90 agregar clumna de estado a la receta

### DIFF
--- a/api/src/models/Receta.ts
+++ b/api/src/models/Receta.ts
@@ -10,6 +10,7 @@ class Receta extends Model {
   declare correo: string
   declare codigo: number;
   declare fecha: Date;
+  declare estado: string;
 }
 
 Receta.init(
@@ -26,6 +27,7 @@ Receta.init(
     correo: DataTypes.STRING(50),
     codigo: DataTypes.INTEGER,
     fecha: DataTypes.DATE,
+    estado: DataTypes.STRING(50),
   },
   {
     sequelize,

--- a/api/src/types/Receta.ts
+++ b/api/src/types/Receta.ts
@@ -10,6 +10,7 @@ export interface RecetaAttributes {
   correo: string | null;
   codigo: number | null;
   fecha: Date | null;
+  estado: string | null;
 }
 
 export interface RecetaCreationAttributes {
@@ -22,6 +23,7 @@ export interface RecetaCreationAttributes {
   correo?: string | null;
   codigo?: number | null;
   fecha?: Date | null;
+  estado?: "Pendiente" | "Retirado" | "Vencido" | null;
 }
 
 export interface RecetasDosisAttributes {

--- a/web/app/pages/admin/components/RecetaTable.tsx
+++ b/web/app/pages/admin/components/RecetaTable.tsx
@@ -3,7 +3,9 @@ import {
   Box,
   Button,
   CircularProgress,
+  MenuItem,
   Paper,
+  Select,
   Table,
   TableBody,
   TableCell,
@@ -16,6 +18,7 @@ import {
 import { useState } from 'react';
 import { useGetRecetas, useUpdateRecetaMutation } from '~/lib/api/QueryReceta';
 import type { RecetaUpdate } from '~/types/receta';
+import type { Receta } from '~/types/receta';
 
 function formatDateForInput(value: string | Date | null | undefined) {
   if (!value) return '';
@@ -31,17 +34,7 @@ export function RecetaTable() {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editForm, setEditForm] = useState<RecetaUpdate>({});
 
-  const handleRowClick = (receta: {
-    id: number;
-    id_cliente: number;
-    doctor_remitente: string | null;
-    ruc_doctor_remitente: string | null;
-    hospital_remitente: string | null;
-    telefono_hospital: string | null;
-    correo: string | null;
-    codigo: number | null;
-    fecha: string | Date | null;
-  }) => {
+  const handleRowClick = (receta: Receta) => {
     if (updatingId) return;
 
     setEditingId(receta.id);
@@ -54,6 +47,7 @@ export function RecetaTable() {
       correo: receta.correo ?? '',
       codigo: receta.codigo,
       fecha: receta.fecha ? new Date(receta.fecha) : null,
+      estado: (receta.estado as "Pendiente" | "Retirado" | "Vencido" | null | undefined) ?? null,
     });
   };
 
@@ -106,6 +100,7 @@ export function RecetaTable() {
             <TableCell><strong>Correo</strong></TableCell>
             <TableCell><strong>Código</strong></TableCell>
             <TableCell><strong>Fecha</strong></TableCell>
+            <TableCell><strong>Estado</strong></TableCell>
             <TableCell><strong>Acciones</strong></TableCell>
           </TableRow>
         </TableHead>
@@ -215,6 +210,23 @@ export function RecetaTable() {
                   />
                 ) : (
                   formatDateForInput(receta.fecha) || 'N/A'
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === receta.id ? (
+                  <Select
+                    value={formatDateForInput(editForm.estado)}
+                    size="small"
+                    type='text'
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => handleFieldChange('estado', e.target.value ? e.target.value as "Pendiente" | "Retirado" | "Vencido" : null)}
+                  >
+                    <MenuItem value="Pendiente">Pendiente</MenuItem>
+                    <MenuItem value="Retirado">Retirado</MenuItem>
+                    <MenuItem value="Vencido">Vencido</MenuItem>
+                  </Select>
+                ) : (
+                  receta.estado || 'N/A'
                 )}
               </TableCell>
               <TableCell>

--- a/web/app/pages/dashboard/components/PatientsTable.tsx
+++ b/web/app/pages/dashboard/components/PatientsTable.tsx
@@ -117,7 +117,6 @@ export function PatientsTable({
                   <TableRow
                     key={row.id}
                     hover
-                    onClick={() => handleRowClick(row.cedula ?? '')}
                     sx={{
                       cursor: 'pointer',
                       transition: 'background-color 0.2s',

--- a/web/app/pages/historial/route.tsx
+++ b/web/app/pages/historial/route.tsx
@@ -39,8 +39,6 @@ export default function Historial() {
     isError: errorRecetas,
   } = useGetRecetasYDosisByCedula(cedula, !!cedula);
 
-  console.log('Recetas con dosis e inventario:', recetas);
-
   const loading = loadingCliente || loadingRecetas;
   const error = errorCliente || errorRecetas;
 
@@ -124,8 +122,8 @@ export default function Historial() {
                           {receta.doctor_remitente ?? 'Doctor no especificado'}
                         </Typography>
                         <Chip
-                          label={receta.activo ? 'Activa' : 'Inactiva'}
-                          color={receta.activo ? 'success' : 'default'}
+                          label={receta.estado || 'Estado desconocido'}
+                          color={receta.estado === 'Pendiente' ? 'warning' : receta.estado === 'Retirado' ? 'success' : receta.estado === 'Vencido' ? 'error' : 'default'}
                           size="small"
                         />
                       </Box>

--- a/web/app/pages/nueva-receta/components/DosisField.tsx
+++ b/web/app/pages/nueva-receta/components/DosisField.tsx
@@ -1,0 +1,87 @@
+import  { Paper, Box, Typography, IconButton, TextField, MenuItem } from "@mui/material";
+import  { Controller } from "react-hook-form";
+import DeleteIcon from '@mui/icons-material/Delete';
+
+
+export default function DosisField({ index, control, errors, inventarios, onRemove }: {
+  index: number;
+  control: any;
+  errors: any;
+  inventarios: any[];
+  onRemove: () => void;
+}) {
+  return (
+    <Paper sx={{ p: 2, mb: 2 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+          Medicina #{index + 1}
+        </Typography>
+        <IconButton onClick={onRemove} color="error">
+          <DeleteIcon />
+        </IconButton>
+      </Box>
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr 1fr' }, gap: 2 }}>
+        <Box>
+          <Controller
+            name={`Dosis.${index}.id_medicamento`}
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                select
+                fullWidth
+                label="Medicina"
+                value={field.value ?? ''}
+                onChange={(e) => field.onChange(Number(e.target.value))}
+                error={!!errors?.Dosis?.[index]?.id_medicamento}
+                helperText={errors?.Dosis?.[index]?.id_medicamento?.message}
+              >
+                <MenuItem value="">Seleccionar medicina</MenuItem>
+                {inventarios?.map((inv: any) => (
+                  <MenuItem key={inv.id} value={inv.id}>
+                    {inv.nombre_medicamento} - {inv.marca}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
+        </Box>
+        <Box>
+          <Controller
+            name={`Dosis.${index}.cantidad`}
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="Cantidad"
+                type="number"
+                value={field.value ?? ''}
+                onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : null)}
+                error={!!errors?.Dosis?.[index]?.cantidad}
+                helperText={errors?.Dosis?.[index]?.cantidad?.message}
+              />
+            )}
+          />
+        </Box>
+        <Box>
+          <Controller
+            name={`Dosis.${index}.instrucciones`}
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="Instrucciones"
+                value={field.value ?? ''}
+                onChange={(e) => field.onChange(e.target.value)}
+                error={!!errors?.Dosis?.[index]?.instrucciones}
+                helperText={errors?.Dosis?.[index]?.instrucciones?.message}
+              />
+            )}
+          />
+        </Box>
+      </Box>
+    </Paper>
+  );
+}

--- a/web/app/pages/nueva-receta/route.tsx
+++ b/web/app/pages/nueva-receta/route.tsx
@@ -1,5 +1,4 @@
 import { useSearchParams, useNavigate } from 'react-router';
-import { useGetRecetasByCedula } from '~/lib/api/QueryReceta';
 import { useGetClienteByCedula } from '~/lib/api/QueryCliente';
 import { useGetUsuario } from '~/lib/api/QueryUsuario';
 import { useCreateRecetaWithDosisMutation } from '~/lib/api/QueryReceta';
@@ -14,120 +13,17 @@ import {
   Button,
   CircularProgress,
   Alert,
-  MenuItem,
-  IconButton,
+  InputLabel,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import AddIcon from '@mui/icons-material/Add';
-import DeleteIcon from '@mui/icons-material/Delete';
 import SaveIcon from '@mui/icons-material/Save';
+import { RecetasDosisSchema, type RecetasDosisCreation } from '~/types/receta';
 import { useState, useEffect } from 'react';
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
 import { Navbar } from '../dashboard/components/Navbar';
-
-const DosisSchema = z.object({
-  id_medicamento: z.number().nullable().optional(),
-  cantidad: z.number().nullable().optional(),
-  instrucciones: z.string().nullable().optional(),
-});
-
-const RecetaFormSchema = z.object({
-  id_cliente: z.number(),
-  doctor_remitente: z.string().min(1, 'El nombre del doctor es requerido'),
-  ruc_doctor_remitente: z.string().nullable().optional(),
-  hospital_remitente: z.string().min(1, 'El hospital es requerido'),
-  telefono_hospital: z.string().nullable().optional(),
-  codigo: z.number().nullable().optional(),
-  fecha: z.date().nullable().optional(),
-  Dosis: z.array(DosisSchema).min(1, 'Al menos una medicina es requerida'),
-});
-
-type RecetaFormData = z.infer<typeof RecetaFormSchema>;
-
-function DosisField({ index, control, errors, inventarios, onRemove }: {
-  index: number;
-  control: any;
-  errors: any;
-  inventarios: any[];
-  onRemove: () => void;
-}) {
-  return (
-    <Paper sx={{ p: 2, mb: 2 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-          Medicina #{index + 1}
-        </Typography>
-        <IconButton onClick={onRemove} color="error">
-          <DeleteIcon />
-        </IconButton>
-      </Box>
-      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr 1fr' }, gap: 2 }}>
-        <Box>
-          <Controller
-            name={`Dosis.${index}.id_medicamento`}
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                select
-                fullWidth
-                label="Medicina"
-                value={field.value ?? ''}
-                onChange={(e) => field.onChange(Number(e.target.value))}
-                error={!!errors?.Dosis?.[index]?.id_medicamento}
-                helperText={errors?.Dosis?.[index]?.id_medicamento?.message}
-              >
-                <MenuItem value="">Seleccionar medicina</MenuItem>
-                {inventarios?.map((inv: any) => (
-                  <MenuItem key={inv.id} value={inv.id}>
-                    {inv.nombre_medicamento} - {inv.marca}
-                  </MenuItem>
-                ))}
-              </TextField>
-            )}
-          />
-        </Box>
-        <Box>
-          <Controller
-            name={`Dosis.${index}.cantidad`}
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                fullWidth
-                label="Cantidad"
-                type="number"
-                value={field.value ?? ''}
-                onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : null)}
-                error={!!errors?.Dosis?.[index]?.cantidad}
-                helperText={errors?.Dosis?.[index]?.cantidad?.message}
-              />
-            )}
-          />
-        </Box>
-        <Box>
-          <Controller
-            name={`Dosis.${index}.instrucciones`}
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                fullWidth
-                label="Instrucciones"
-                value={field.value ?? ''}
-                onChange={(e) => field.onChange(e.target.value)}
-                error={!!errors?.Dosis?.[index]?.instrucciones}
-                helperText={errors?.Dosis?.[index]?.instrucciones?.message}
-              />
-            )}
-          />
-        </Box>
-      </Box>
-    </Paper>
-  );
-}
+import DosisField from './components/DosisField';
 
 export default function NuevaReceta() {
   const [searchParams] = useSearchParams();
@@ -158,16 +54,19 @@ export default function NuevaReceta() {
     control,
     formState: { errors },
     setValue,
-  } = useForm<RecetaFormData>({
-    resolver: zodResolver(RecetaFormSchema),
+  } = useForm<RecetasDosisCreation>({
+    resolver: zodResolver(RecetasDosisSchema),
     defaultValues: {
-      id_cliente: 0,
-      doctor_remitente: '',
-      ruc_doctor_remitente: '',
-      hospital_remitente: '',
-      telefono_hospital: '',
-      codigo: Math.floor(Math.random() * 90000) + 10000,
-      fecha: new Date(),
+      Receta: {
+        id_cliente: 0,
+        doctor_remitente: '',
+        ruc_doctor_remitente: '',
+        hospital_remitente: '',
+        telefono_hospital: '',
+        codigo: Math.floor(Math.random() * 90000) + 10000,
+        fecha: new Date(),
+        estado: 'Pendiente',
+      },
       Dosis: [
         {
           id_medicamento: null,
@@ -185,25 +84,23 @@ export default function NuevaReceta() {
 
   useEffect(() => {
     if (cliente) {
-      setValue('id_cliente', Number(cliente.id));
+      setValue('Receta.id_cliente', Number(cliente.id));
     }
   }, [cliente, setValue]);
 
   useEffect(() => {
     if (usuario && usuario.length > 0) {
       const doc = usuario[0];
-      setValue('doctor_remitente', `${doc.nombre} ${doc.apellido}`.trim());
-      setValue('ruc_doctor_remitente', doc.ruc_doctor || '');
+      setValue('Receta.doctor_remitente', `${doc.nombre} ${doc.apellido}`.trim());
+      setValue('Receta.ruc_doctor_remitente', doc.ruc_doctor || '');
     }
   }, [usuario, setValue]);
 
-  const onSubmit = async (data: RecetaFormData) => {
+  const onSubmit = async (data: RecetasDosisCreation) => {
     try {
       await createRecetaMutation.mutateAsync({
         Receta: {
-          ...data,
-          codigo: data.codigo || Math.floor(Math.random() * 90000) + 10000,
-          fecha: new Date(),
+          ...data.Receta,
         },
         Dosis: data.Dosis.map((d) => ({
           ...d,
@@ -282,7 +179,7 @@ export default function NuevaReceta() {
             <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2, mb: 3 }}>
               <Box>
                 <Controller
-                  name="doctor_remitente"
+                  name="Receta.doctor_remitente"
                   control={control}
                   render={({ field }) => (
                     <TextField
@@ -296,7 +193,7 @@ export default function NuevaReceta() {
               </Box>
               <Box>
                 <Controller
-                  name="ruc_doctor_remitente"
+                  name="Receta.ruc_doctor_remitente"
                   control={control}
                   render={({ field }) => (
                     <TextField
@@ -310,35 +207,51 @@ export default function NuevaReceta() {
               </Box>
               <Box>
                 <Controller
-                  name="hospital_remitente"
+                  name="Receta.hospital_remitente"
                   control={control}
                   render={({ field }) => (
                     <TextField
                       {...field}
                       fullWidth
                       label="Hospital"
-                      error={!!errors.hospital_remitente}
-                      helperText={errors.hospital_remitente?.message}
+                      error={!!errors.Receta?.hospital_remitente}
+                      helperText={errors.Receta?.hospital_remitente?.message}
                     />
                   )}
                 />
               </Box>
               <Box>
                 <Controller
-                  name="telefono_hospital"
+                  name="Receta.telefono_hospital"
                   control={control}
                   render={({ field }) => (
                     <TextField
                       {...field}
                       fullWidth
                       label="Teléfono Hospital"
+                      error={!!errors.Receta?.telefono_hospital}
+                      helperText={errors.Receta?.telefono_hospital?.message}
+                    />
+                  )}
+                />
+              </Box>
+              <Box>
+                <InputLabel sx={{ mb: 1 }}>Expiración de la receta</InputLabel>
+                <Controller
+                  name="Receta.fecha"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      fullWidth
+                      type="date"
                     />
                   )}
                 />
               </Box>
               <Box>
                 <Controller
-                  name="codigo"
+                  name="Receta.codigo"
                   control={control}
                   render={({ field }) => (
                     <TextField

--- a/web/app/types/receta.ts
+++ b/web/app/types/receta.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { DosisCreationSchema } from './Dosis';
+import { es } from 'zod/v4/locales';
 
 const DosisInRecetaCreationSchema = DosisCreationSchema.omit({ id_receta: true });
 
@@ -15,6 +16,7 @@ export const RecetaSchema = z.object({
   correo: z.email().nullable(),
   codigo: z.number().nullable(),
   fecha: z.date().nullable(),
+  estado: z.string().nullable(),
 });
 
 // Schema para creación
@@ -28,6 +30,7 @@ export const RecetaCreationSchema = z.object({
   correo: z.email().nullable().optional(),
   codigo: z.number().nullable().optional(),
   fecha: z.date().nullable().optional(),
+  estado: z.enum(["Pendiente", "Retirado", "Vencido"]).nullable().optional(),
 });
 
 // Schema para actualización (todos los campos opcionales excepto id)


### PR DESCRIPTION
This pull request introduces the new `estado` (status) field to the `Receta` model, updates related TypeScript types and validation schemas, and refactors the UI to support viewing and editing this new field across the admin, patient history, and prescription creation workflows. Additionally, it modularizes the `DosisField` component for better maintainability and updates the prescription creation form to use a nested object structure for `Receta` data.

**Backend and Type Definitions:**

* Added `estado` field to the `Receta` model, database schema, and TypeScript types, enabling tracking of prescription status as "Pendiente", "Retirado", or "Vencido". [[1]](diffhunk://#diff-cdcb9fd5c66a9d0373318a44318ee4e9188f071006e9f89d4d59b5ed4d3b843aR13) [[2]](diffhunk://#diff-cdcb9fd5c66a9d0373318a44318ee4e9188f071006e9f89d4d59b5ed4d3b843aR30) [[3]](diffhunk://#diff-046109d6156acda7d7c4d2e7d8e234e05488e3715bf477ba0f5affb0e317da2dR13) [[4]](diffhunk://#diff-046109d6156acda7d7c4d2e7d8e234e05488e3715bf477ba0f5affb0e317da2dR26) [[5]](diffhunk://#diff-6ddff97bd522867e232af935eb7d92945d0c651b152ed32fc8f6ec985cf412d4R19)

**Admin UI Enhancements:**

* Updated the admin `RecetaTable` to display and allow editing of the `estado` field via a dropdown, ensuring admins can manage prescription statuses directly from the table. [[1]](diffhunk://#diff-cb4b93a8e50f0e0f748d99dc8d252ab7788ce7870343c34db2052bd6c207c8edR6-R8) [[2]](diffhunk://#diff-cb4b93a8e50f0e0f748d99dc8d252ab7788ce7870343c34db2052bd6c207c8edR21) [[3]](diffhunk://#diff-cb4b93a8e50f0e0f748d99dc8d252ab7788ce7870343c34db2052bd6c207c8edL34-R37) [[4]](diffhunk://#diff-cb4b93a8e50f0e0f748d99dc8d252ab7788ce7870343c34db2052bd6c207c8edR50) [[5]](diffhunk://#diff-cb4b93a8e50f0e0f748d99dc8d252ab7788ce7870343c34db2052bd6c207c8edR103) [[6]](diffhunk://#diff-cb4b93a8e50f0e0f748d99dc8d252ab7788ce7870343c34db2052bd6c207c8edR215-R231)

**Patient History UI Improvements:**

* Modified the patient history view to display the new `estado` field with color-coded chips, replacing the previous `activo` status display for better clarity.

**Prescription Creation Refactor:**

* Refactored the prescription creation form to use a nested `Receta` object, updated validation to use the new `RecetasDosisSchema`, and set the default `estado` to "Pendiente". Also improved field naming and error handling for all `Receta` fields. [[1]](diffhunk://#diff-1279a9461cf425c2f14158fb63ea395593d039fa1c49e0c3d9d08f650bfd2a8aL17-R26) [[2]](diffhunk://#diff-1279a9461cf425c2f14158fb63ea395593d039fa1c49e0c3d9d08f650bfd2a8aL161-R69) [[3]](diffhunk://#diff-1279a9461cf425c2f14158fb63ea395593d039fa1c49e0c3d9d08f650bfd2a8aL188-R103) [[4]](diffhunk://#diff-1279a9461cf425c2f14158fb63ea395593d039fa1c49e0c3d9d08f650bfd2a8aL285-R182) [[5]](diffhunk://#diff-1279a9461cf425c2f14158fb63ea395593d039fa1c49e0c3d9d08f650bfd2a8aL299-R196) [[6]](diffhunk://#diff-1279a9461cf425c2f14158fb63ea395593d039fa1c49e0c3d9d08f650bfd2a8aL313-R254)

**Component Modularization:**

* Extracted the `DosisField` component from the prescription creation page into its own file, simplifying the main form and promoting code reuse. [[1]](diffhunk://#diff-1279a9461cf425c2f14158fb63ea395593d039fa1c49e0c3d9d08f650bfd2a8aL17-R26) [[2]](diffhunk://#diff-4584028242c326c6ae47def7b367e6409aa287267aa5d3eab4a14cf231ac2d28R1-R87)

These changes collectively improve the prescription workflow by allowing status tracking, enhancing UI clarity, and modernizing form structure and validation.