### PR TITLE
Integrate push notification handling with id_acceso in NuevaReceta

### DIFF
--- a/api/src/controllers/CRUD_PushNotification.ts
+++ b/api/src/controllers/CRUD_PushNotification.ts
@@ -10,10 +10,10 @@ import {
 
 async function registerToken(request: Request, response: Response) {
   try {
-    const { id_cliente, push_token }: RegisterTokenBody = request.body;
+    const { id_acceso, push_token }: RegisterTokenBody = request.body;
 
-    if (!id_cliente || !push_token) {
-      return response.status(400).json({ error: 'id_cliente y push_token son requeridos' });
+    if (!id_acceso || !push_token) {
+      return response.status(400).json({ error: 'id_acceso y push_token son requeridos' });
     }
 
     const valid =
@@ -26,7 +26,7 @@ async function registerToken(request: Request, response: Response) {
 
     const [affected] = await Cliente.update(
       { push_token },
-      { where: { id: id_cliente } }
+      { where: { id_acceso } }
     );
 
     if (affected === 0) {
@@ -41,13 +41,13 @@ async function registerToken(request: Request, response: Response) {
 
 async function sendNotification(request: Request, response: Response) {
   try {
-    const { id_cliente, type, data = {} }: SendNotificationBody = request.body;
+    const { id_acceso, type, data = {} }: SendNotificationBody = request.body;
 
-    if (!id_cliente || !type) {
-      return response.status(400).json({ error: 'id_cliente y type son requeridos' });
+    if (!id_acceso || !type) {
+      return response.status(400).json({ error: 'id_acceso y type son requeridos' });
     }
 
-    const cliente = await Cliente.findByPk(id_cliente);
+    const cliente = await Cliente.findOne({ where: { id_acceso } });
 
     if (!cliente) {
       return response.status(404).json({ error: 'Cliente no encontrado' });

--- a/api/src/types/PushNotification.ts
+++ b/api/src/types/PushNotification.ts
@@ -29,12 +29,12 @@ export type NotificationType =
   | 'recordatorio-receta';
 
 export interface SendNotificationBody {
-  id_cliente: number;
+  id_acceso: string;
   type: NotificationType;
   data?: Record<string, unknown>;
 }
 
 export interface RegisterTokenBody {
-  id_cliente: number;
+  id_acceso: string;
   push_token: string;
 }

--- a/web/app/lib/api/QueryNotification.ts
+++ b/web/app/lib/api/QueryNotification.ts
@@ -1,0 +1,25 @@
+import { useMutation } from '@tanstack/react-query';
+import { apiJson } from '../apiClient';
+
+type NotificationType =
+  | 'nueva-receta'
+  | 'receta-por-expirar'
+  | 'receta-retirada'
+  | 'recordatorio-receta';
+
+interface SendNotificationPayload {
+  id_acceso: string;
+  type: NotificationType;
+  data?: Record<string, unknown>;
+}
+
+export const useSendPushNotificationMutation = () => {
+  return useMutation({
+    mutationFn: (payload: SendNotificationPayload) =>
+      apiJson<{ message: string }>('/notifications/send', {
+        method: 'POST',
+        body: payload,
+        auth: true,
+      }),
+  });
+};

--- a/web/app/pages/nueva-receta/route.tsx
+++ b/web/app/pages/nueva-receta/route.tsx
@@ -2,6 +2,7 @@ import { useSearchParams, useNavigate } from 'react-router';
 import { useGetClienteByCedula } from '~/lib/api/QueryCliente';
 import { useGetUsuario } from '~/lib/api/QueryUsuario';
 import { useCreateRecetaWithDosisMutation } from '~/lib/api/QueryReceta';
+import { useSendPushNotificationMutation } from '~/lib/api/QueryNotification';
 import { useGetInventario } from '~/lib/api/QueryInventario';
 import { useProtectedRoute } from '~/lib/useProtectedRoute';
 import { GetSession } from '~/lib/GetSession';
@@ -43,6 +44,7 @@ export default function NuevaReceta() {
   const { isLoading: loadingInventario } = useGetInventario('all', true);
 
   const createRecetaMutation = useCreateRecetaWithDosisMutation();
+  const sendNotification = useSendPushNotificationMutation();
 
   const {
     handleSubmit,
@@ -90,6 +92,16 @@ export default function NuevaReceta() {
           cantidad: d.cantidad ? Number(d.cantidad) : null,
         })),
       });
+
+      // Fire-and-forget: no bloquea el flujo si la notificacion falla
+      if (cliente?.id_acceso) {
+        sendNotification.mutate({
+          id_acceso: cliente.id_acceso,
+          type: 'nueva-receta',
+          data: { doctor: doctorName },
+        });
+      }
+
       setSuccessMessage(true);
       setTimeout(() => navigate('/home'), 1500);
     } catch (error) {


### PR DESCRIPTION
This pull request updates the push notification system to use `id_acceso` (access ID) instead of `id_cliente` (client ID) for identifying users across both backend and frontend. It also introduces a new React Query mutation hook on the frontend for sending push notifications, and integrates it into the "Nueva Receta" flow to send a notification when a new prescription is created.

**Backend changes:**

* All push notification controller methods and type definitions now use `id_acceso` instead of `id_cliente` for identifying users, including error messages and database lookups. [[1]](diffhunk://#diff-28bb015a853b06e50c0056e4498ad78f796f25977229f99f434d9b1b22f73affL13-R16) [[2]](diffhunk://#diff-28bb015a853b06e50c0056e4498ad78f796f25977229f99f434d9b1b22f73affL29-R29) [[3]](diffhunk://#diff-28bb015a853b06e50c0056e4498ad78f796f25977229f99f434d9b1b22f73affL44-R50) [[4]](diffhunk://#diff-9976221bb4a655396573ff9a7bba7ae6db2d16a83d8fb9e08343c3903d7a6f3eL32-R38)

**Frontend changes:**

* Added a new React Query mutation hook, `useSendPushNotificationMutation`, in `QueryNotification.ts` for sending push notifications.
* Integrated push notification sending into the prescription creation flow in `nueva-receta/route.tsx`, firing a "nueva-receta" notification after successfully creating a prescription. [[1]](diffhunk://#diff-1279a9461cf425c2f14158fb63ea395593d039fa1c49e0c3d9d08f650bfd2a8aR5) [[2]](diffhunk://#diff-1279a9461cf425c2f14158fb63ea395593d039fa1c49e0c3d9d08f650bfd2a8aR47) [[3]](diffhunk://#diff-1279a9461cf425c2f14158fb63ea395593d039fa1c49e0c3d9d08f650bfd2a8aR95-R104)…e notification sending in NuevaReceta